### PR TITLE
Add story for recently viewed widget

### DIFF
--- a/packages/featured-content/stories/FeaturedContentWithDataFetching.stories.tsx
+++ b/packages/featured-content/stories/FeaturedContentWithDataFetching.stories.tsx
@@ -154,10 +154,10 @@ const mockContentItemFactory = (isLearningPath = false) => ({
   courseGracePeriodEnded: false,
   coursePresold: false,
   courseStartDate: '2016-11-07T05:51:02.856Z',
-  description: 'We need to compress the auxiliary COM pixel!',
+  description: 'Test description',
   rating: 78,
-  slug: 'perverted-rabbit-warfare',
-  title: 'Perverted Rabbit Warfare',
+  slug: 'test-course-slug',
+  title: 'Test title',
   kind: isLearningPath ? ContentKind.LearningPath : null,
   currentUserUnmetCoursePrerequisites: [],
   currentUserUnmetLearningPathPrerequisites: [],
@@ -178,15 +178,15 @@ const mockRecentContentItem = {
   courseGracePeriodEnded: false,
   coursePresold: false,
   courseStartDate: '2016-11-07T05:51:02.856Z',
-  description: 'We need to compress the auxiliary COM pixel!',
-  displayCourseSlug: 'perverted-rabbit-warfare',
+  description: 'Test description',
+  displayCourseSlug: 'test-display-course-slug',
   isActive: true,
   kind: ContentKind.CourseGroup,
   sku: null,
-  slug: 'perverted-rabbit-warfare',
+  slug: 'test-course-slug',
   source: null,
   timeZone: 'America/New_York',
-  title: 'Perverted Rabbit Warfare'
+  title: 'Test title'
 };
 const mockApolloResults = {
   catalogQuery: {
@@ -227,7 +227,7 @@ const mockApolloResults = {
   addLearningPathToQueueMutation: {
     request: {
       query: ADD_RESOURCE_TO_QUEUE_MUTATION,
-      variables: { resourceId: 'perverted-rabbit-warfare', resourceType: ContentKind.LearningPath }
+      variables: { resourceId: 'test-course-slug', resourceType: ContentKind.LearningPath }
     },
     result: {
       data: {


### PR DESCRIPTION
The recently viewed widget fetches data for user recently viewed contents, it has options in the manager interface to toggle between variants tile standard layout and multi carousel. We added stories to demonstrate data fetching through catalog queries, thought we could use similar setup to demonstrate the recently viewed widget.

Add helium endpoint to support user recently viewed contents, PR: https://github.com/thoughtindustries/ti/pull/6906

Closes #52 