### PR TITLE
fix: remove stylings

### DIFF
--- a/packages/featured-content/__tests__/featured-content.test.tsx
+++ b/packages/featured-content/__tests__/featured-content.test.tsx
@@ -121,7 +121,7 @@ describe('@thoughtindustries/featured-content', () => {
             class="w-auto -ml-4 -mr-4 mt-0 mb-0 max-w-none"
           >
             <div
-              class="w-full relative pl-4 pr-4 float-left grid grid-cols-1 md:grid-cols-4 gap-8"
+              class="w-full relative pl-4 pr-4 grid grid-cols-1 md:grid-cols-4 gap-8"
             >
               <div
                 class="md:col-span-full"
@@ -462,7 +462,7 @@ describe('@thoughtindustries/featured-content', () => {
             class="w-auto -ml-4 -mr-4 mt-0 mb-0 max-w-none"
           >
             <div
-              class="w-full relative pl-4 pr-4 float-left grid grid-cols-1 md:grid-cols-4 gap-8"
+              class="w-full relative pl-4 pr-4 grid grid-cols-1 md:grid-cols-4 gap-8"
             >
               <div
                 class="relative"

--- a/packages/featured-content/src/featured-content.tsx
+++ b/packages/featured-content/src/featured-content.tsx
@@ -12,7 +12,7 @@ const FeaturedContent = ({
   );
   return (
     <div className="w-auto -ml-4 -mr-4 mt-0 mb-0 max-w-none">
-      <div className="w-full relative pl-4 pr-4 float-left grid grid-cols-1 md:grid-cols-4 gap-8">
+      <div className="w-full relative pl-4 pr-4 grid grid-cols-1 md:grid-cols-4 gap-8">
         {sidebarPosition === SidebarPosition.Left && wrappedSidebar}
         {wrappedChildren}
         {sidebarPosition === SidebarPosition.Right && wrappedSidebar}


### PR DESCRIPTION
The styling `float-left` was causing overlapping of sibling ui elements. fix to remove the stylings.

Closes: #89 