### PR TITLE
feat: allow custom catalog pagination

### DIFF
--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -32,4 +32,11 @@ const config = {
 <CatalogProvider config={config}>
   <Catalog onAddedToQueue={(item) => Promise.resolve()} />
 </CatalogProvider>
+
+# Or use custom pagination
+<CatalogProvider config={config}>
+  <Catalog 
+    onAddedToQueue={(item) => Promise.resolve()}
+    pagination={({page, pageSize, total, getPageLink}) => <>...</>} />
+</CatalogProvider>
 ```

--- a/packages/catalog/src/catalog-pagination.tsx
+++ b/packages/catalog/src/catalog-pagination.tsx
@@ -1,125 +1,11 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import { useCatalog } from './core';
-import { PAGINATION_INNER_WINDOW, PAGINATION_MAX_PAGES } from './constants';
-import clsx from 'clsx';
-import { ArrowLeftIcon, ArrowRightIcon, DoubleArrowLeftIcon, DoubleArrowRightIcon } from './icons';
+import { CatalogProps } from './types';
+import Pagination from './pagination';
 
-type VisiblePage = {
-  number: number;
-  label: number | string;
-  isActive?: boolean;
-  isFirst?: boolean;
-  isLast?: boolean;
-};
-const getVisiblePages = (page: number, lastPage: number): VisiblePage[] => {
-  const series: VisiblePage[] = [];
+type CatalogPaginationProps = Pick<CatalogProps, 'pagination'>;
 
-  if (lastPage === 1) {
-    return series;
-  }
-
-  if (lastPage <= PAGINATION_MAX_PAGES) {
-    // 7 or less entries
-    for (let i = 1; i <= lastPage; i++) {
-      const pageNumber = i;
-      series.push({
-        number: pageNumber,
-        label: pageNumber,
-        isActive: page === pageNumber,
-        isFirst: i === 1,
-        isLast: i === lastPage
-      });
-    }
-    return series;
-  }
-
-  if (page >= lastPage - PAGINATION_INNER_WINDOW) {
-    // end of pages
-    series.push({
-      number: Math.max(page - 5, 1),
-      label: '...',
-      isFirst: true
-    });
-
-    for (let i = lastPage - 5; i <= lastPage; i++) {
-      series.push({
-        number: i,
-        label: i,
-        isActive: page === i,
-        isFirst: false,
-        isLast: i === lastPage
-      });
-    }
-
-    return series;
-  }
-
-  if (page - PAGINATION_INNER_WINDOW <= 1) {
-    // beginning of pages
-    for (let i = 1; i <= 6; i++) {
-      series.push({
-        number: i,
-        label: i,
-        isActive: page === i,
-        isFirst: i === 1
-      });
-    }
-
-    series.push({
-      number: Math.min(page + 5, lastPage),
-      label: '...',
-      isLast: true
-    });
-
-    return series;
-  }
-
-  series.push({
-    number: Math.max(page - 5, 1),
-    label: '...',
-    isFirst: true
-  });
-
-  for (let i = page - 2; i < page + PAGINATION_INNER_WINDOW; i++) {
-    series.push({
-      number: i,
-      label: i,
-      isActive: page === i
-    });
-  }
-
-  series.push({
-    number: Math.min(page + 5, lastPage),
-    label: '...',
-    isLast: true
-  });
-
-  return series;
-};
-
-type DisplayedPageRange = {
-  start: number;
-  end: number;
-};
-const getDisplayedPageRange = (
-  page: number,
-  pageSize: number,
-  total: number
-): DisplayedPageRange => {
-  let start, end;
-  if (page === 1) {
-    start = 1;
-  } else {
-    start = (page - 1) * pageSize + 1;
-  }
-  end = start + pageSize - 1;
-  if (end > total) {
-    end = total;
-  }
-  return { start, end };
-};
-
-const CatalogPagination = (): JSX.Element | null => {
+const CatalogPagination = ({ pagination }: CatalogPaginationProps): JSX.Element | null => {
   const { params, urlManager } = useCatalog();
   const { page = 1, pageSize, total } = params;
 
@@ -128,108 +14,19 @@ const CatalogPagination = (): JSX.Element | null => {
   }
 
   // derived values
-  const lastPage = Math.ceil(total / pageSize) || 1;
-  const hasPrevPage = page > 1;
-  const hasNextPage = page < lastPage;
-  const prevPage = page - 1;
-  const nextPage = page + 1;
-  const visiblePages = getVisiblePages(page, lastPage);
-  const { start, end } = getDisplayedPageRange(page, pageSize, total);
+  const getPageLink = urlManager.composeURLForSetPage.bind(urlManager);
+  const props = {
+    page,
+    pageSize,
+    total,
+    getPageLink
+  };
 
-  // stylings
-  const pageBaseClassnames =
-    'w-7 h-7 rounded-none border border-solid border-gray-400 bg-white flex items-center justify-center p-1';
-  const disabledClassnames =
-    'cursor-default pointer-events-none text-gray-400 bg-gray-300 border-gray-300';
-  const enabledClassnames = 'text-gray-600';
-  const firstPageClassnames = clsx(
-    [pageBaseClassnames, 'rounded rounded-r-none border-r-0'],
-    !hasPrevPage ? disabledClassnames : enabledClassnames
-  );
-  const prevPageClassnames = clsx(
-    [pageBaseClassnames, 'rounded rounded-l-none border-r-1 mr-2'],
-    !hasPrevPage ? disabledClassnames : enabledClassnames
-  );
-  const nextPageClassnames = clsx(
-    [pageBaseClassnames, 'rounded rounded-r-none border-r-0 ml-2'],
-    !hasNextPage ? disabledClassnames : enabledClassnames
-  );
-  const lastPageClassnames = clsx(
-    [pageBaseClassnames, 'rounded rounded-l-none border-r-1'],
-    !hasNextPage ? disabledClassnames : enabledClassnames
-  );
+  if (pagination) {
+    return cloneElement(pagination({ ...props }));
+  }
 
-  // components
-  const visiblePagesContent = visiblePages.map(({ number, label, isActive, isFirst, isLast }) => {
-    const firstLastBorderClassnames = isFirst
-      ? 'border-l-1 border-r-0 rounded-r-none'
-      : 'border-r-1 border-l-0 rounded-l-none';
-    const borderClassnames =
-      isFirst || isLast ? clsx('rounded', firstLastBorderClassnames) : 'border-x-0';
-    return (
-      <a
-        key={`catalog-page-${label}`}
-        href={urlManager.composeURLForSetPage(number)}
-        className={clsx(
-          [pageBaseClassnames, borderClassnames],
-          isActive
-            ? 'cursor-default pointer-events-none bg-accent border-accent text-accent-contrast'
-            : 'text-gray-600'
-        )}
-      >
-        {label}
-      </a>
-    );
-  });
-
-  return (
-    <div className="mx-2 my-4 flex flex-wrap-reverse items-center justify-between">
-      <div className="mt-2 flex items-center justify-start">
-        <span>
-          Showing{' '}
-          <strong>
-            {start}-{end}
-          </strong>{' '}
-          of <strong>{total} items</strong>
-        </span>
-      </div>
-      {!!visiblePages.length && (
-        <div className="mt-2 flex items-center justify-end">
-          <div className="flex justify-center">
-            <a
-              href={urlManager.composeURLForSetPage(1)}
-              className={firstPageClassnames}
-              aria-label="rewind"
-            >
-              <DoubleArrowLeftIcon />
-            </a>
-            <a
-              href={urlManager.composeURLForSetPage(prevPage)}
-              className={prevPageClassnames}
-              aria-label="navigateleft"
-            >
-              <ArrowLeftIcon />
-            </a>
-            {visiblePagesContent}
-            <a
-              href={urlManager.composeURLForSetPage(nextPage)}
-              className={nextPageClassnames}
-              aria-label="navigateright"
-            >
-              <ArrowRightIcon />
-            </a>
-            <a
-              href={urlManager.composeURLForSetPage(lastPage)}
-              className={lastPageClassnames}
-              aria-label="fastforward"
-            >
-              <DoubleArrowRightIcon />
-            </a>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+  return <Pagination {...props} />;
 };
 
 CatalogPagination.displayName = 'CatalogPagination';

--- a/packages/catalog/src/catalog.tsx
+++ b/packages/catalog/src/catalog.tsx
@@ -11,6 +11,7 @@ import CatalogPagination from './catalog-pagination';
 const Catalog: FC<CatalogProps> = ({
   title,
   alternateTitleDisplay,
+  pagination,
   ...restResultsProps
 }: CatalogProps): JSX.Element => {
   const { t } = useTranslation();
@@ -28,7 +29,7 @@ const Catalog: FC<CatalogProps> = ({
             </div>
             <div className="col-span-full md:col-span-3">
               <CatalogResults {...restResultsProps} />
-              <CatalogPagination />
+              <CatalogPagination pagination={pagination} />
             </div>
           </div>
         </CatalogError>

--- a/packages/catalog/src/constants.ts
+++ b/packages/catalog/src/constants.ts
@@ -1,3 +1,8 @@
 // number of pages on either side of active
 export const PAGINATION_INNER_WINDOW = 3;
 export const PAGINATION_MAX_PAGES = PAGINATION_INNER_WINDOW * 2 + 1;
+export const DEFAULT_PAGE = 1;
+
+export const DEFAULT_PAGE_SIZE = 50;
+
+export const DEFAULT_HIDE_PAGE_LIST = false;

--- a/packages/catalog/src/pagination.tsx
+++ b/packages/catalog/src/pagination.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import {
+  DEFAULT_HIDE_PAGE_LIST,
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+  PAGINATION_INNER_WINDOW,
+  PAGINATION_MAX_PAGES
+} from './constants';
+import clsx from 'clsx';
+import { ArrowLeftIcon, ArrowRightIcon, DoubleArrowLeftIcon, DoubleArrowRightIcon } from './icons';
+
+type VisiblePage = {
+  number: number;
+  label: number | string;
+  isActive?: boolean;
+  isFirst?: boolean;
+  isLast?: boolean;
+};
+const getVisiblePages = (page: number, lastPage: number): VisiblePage[] => {
+  const series: VisiblePage[] = [];
+
+  if (lastPage === 1) {
+    return series;
+  }
+
+  if (lastPage <= PAGINATION_MAX_PAGES) {
+    // 7 or less entries
+    for (let i = 1; i <= lastPage; i++) {
+      const pageNumber = i;
+      series.push({
+        number: pageNumber,
+        label: pageNumber,
+        isActive: page === pageNumber,
+        isFirst: i === 1,
+        isLast: i === lastPage
+      });
+    }
+    return series;
+  }
+
+  if (page >= lastPage - PAGINATION_INNER_WINDOW) {
+    // end of pages
+    series.push({
+      number: Math.max(page - 5, 1),
+      label: '...',
+      isFirst: true
+    });
+
+    for (let i = lastPage - 5; i <= lastPage; i++) {
+      series.push({
+        number: i,
+        label: i,
+        isActive: page === i,
+        isFirst: false,
+        isLast: i === lastPage
+      });
+    }
+
+    return series;
+  }
+
+  if (page - PAGINATION_INNER_WINDOW <= 1) {
+    // beginning of pages
+    for (let i = 1; i <= 6; i++) {
+      series.push({
+        number: i,
+        label: i,
+        isActive: page === i,
+        isFirst: i === 1
+      });
+    }
+
+    series.push({
+      number: Math.min(page + 5, lastPage),
+      label: '...',
+      isLast: true
+    });
+
+    return series;
+  }
+
+  series.push({
+    number: Math.max(page - 5, 1),
+    label: '...',
+    isFirst: true
+  });
+
+  for (let i = page - 2; i < page + PAGINATION_INNER_WINDOW; i++) {
+    series.push({
+      number: i,
+      label: i,
+      isActive: page === i
+    });
+  }
+
+  series.push({
+    number: Math.min(page + 5, lastPage),
+    label: '...',
+    isLast: true
+  });
+
+  return series;
+};
+
+type DisplayedPageRange = {
+  start: number;
+  end: number;
+};
+const getDisplayedPageRange = (
+  page: number,
+  pageSize: number,
+  total: number
+): DisplayedPageRange => {
+  let start, end;
+  if (page === 1) {
+    start = 1;
+  } else {
+    start = (page - 1) * pageSize + 1;
+  }
+  end = start + pageSize - 1;
+  if (end > total) {
+    end = total;
+  }
+  return { start, end };
+};
+
+interface PaginationProps {
+  /** Optional current page number */
+  page?: number;
+  /** Total items count */
+  total: number;
+  /** Optional page size */
+  pageSize?: number;
+  /** Function to get link for a given page */
+  getPageLink: (page: number) => string;
+  /** Optional setting to hide page list */
+  hidePageList?: boolean;
+}
+
+const Pagination = ({
+  page = DEFAULT_PAGE,
+  total,
+  pageSize = DEFAULT_PAGE_SIZE,
+  getPageLink,
+  hidePageList = DEFAULT_HIDE_PAGE_LIST
+}: PaginationProps): JSX.Element => {
+  // derived values
+  const lastPage = Math.ceil(total / pageSize) || 1;
+  const hasPrevPage = page > 1;
+  const hasNextPage = page < lastPage;
+  const prevPage = page - 1;
+  const nextPage = page + 1;
+  const visiblePages = getVisiblePages(page, lastPage);
+  const { start, end } = getDisplayedPageRange(page, pageSize, total);
+
+  // stylings
+  const pageBaseClassnames =
+    'w-7 h-7 rounded-none border border-solid border-gray-400 bg-white flex items-center justify-center p-1';
+  const disabledClassnames =
+    'cursor-default pointer-events-none text-gray-400 bg-gray-300 border-gray-300';
+  const enabledClassnames = 'text-gray-600';
+  const firstPageClassnames = clsx(
+    [pageBaseClassnames, 'rounded rounded-r-none border-r-0'],
+    !hasPrevPage ? disabledClassnames : enabledClassnames
+  );
+  const prevPageClassnames = clsx(
+    [pageBaseClassnames, 'rounded rounded-l-none border-r-1 mr-2'],
+    !hasPrevPage ? disabledClassnames : enabledClassnames
+  );
+  const nextPageClassnames = clsx(
+    [pageBaseClassnames, 'rounded rounded-r-none border-r-0 ml-2'],
+    !hasNextPage ? disabledClassnames : enabledClassnames
+  );
+  const lastPageClassnames = clsx(
+    [pageBaseClassnames, 'rounded rounded-l-none border-r-1'],
+    !hasNextPage ? disabledClassnames : enabledClassnames
+  );
+
+  // components
+  const visiblePagesContent = !hidePageList
+    ? visiblePages.map(({ number, label, isActive, isFirst, isLast }) => {
+        const firstLastBorderClassnames = isFirst
+          ? 'border-l-1 border-r-0 rounded-r-none'
+          : 'border-r-1 border-l-0 rounded-l-none';
+        const borderClassnames =
+          isFirst || isLast ? clsx('rounded', firstLastBorderClassnames) : 'border-x-0';
+        return (
+          <a
+            key={`catalog-page-${label}`}
+            href={getPageLink(number)}
+            className={clsx(
+              [pageBaseClassnames, borderClassnames],
+              isActive
+                ? 'cursor-default pointer-events-none bg-accent border-accent text-accent-contrast'
+                : 'text-gray-600'
+            )}
+          >
+            {label}
+          </a>
+        );
+      })
+    : null;
+
+  return (
+    <div className="mx-2 my-4 flex flex-wrap-reverse items-center justify-between">
+      <div className="mt-2 flex items-center justify-start">
+        <span>
+          Showing{' '}
+          <strong>
+            {start}-{end}
+          </strong>{' '}
+          of <strong>{total} items</strong>
+        </span>
+      </div>
+      {!!visiblePages.length && (
+        <div className="mt-2 flex items-center justify-end">
+          <div className="flex justify-center">
+            <a href={getPageLink(1)} className={firstPageClassnames} aria-label="rewind">
+              <DoubleArrowLeftIcon />
+            </a>
+            <a
+              href={getPageLink(prevPage)}
+              className={prevPageClassnames}
+              aria-label="navigateleft"
+            >
+              <ArrowLeftIcon />
+            </a>
+            {visiblePagesContent}
+            <a
+              href={getPageLink(nextPage)}
+              className={nextPageClassnames}
+              aria-label="navigateright"
+            >
+              <ArrowRightIcon />
+            </a>
+            <a href={getPageLink(lastPage)} className={lastPageClassnames} aria-label="fastforward">
+              <DoubleArrowRightIcon />
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+Pagination.displayName = 'Pagination';
+export default Pagination;

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1,4 +1,4 @@
-import { SyntheticEvent } from 'react';
+import { SyntheticEvent, ReactNode, ReactElement } from 'react';
 import { HydratedContentItem, GlobalTypes } from '@thoughtindustries/content';
 
 export type CatalogResultItemRibbon = GlobalTypes.Ribbon;
@@ -16,9 +16,19 @@ export interface CatalogResultsProps {
   onClick?: (evt: SyntheticEvent, item: CatalogResultItem) => void;
 }
 
+export type PaginationFnArgs = {
+  page: number;
+  pageSize: number;
+  total: number;
+  getPageLink: (page: number) => string;
+};
+export type PaginationFn = (args: PaginationFnArgs) => ReactElement;
+
 export interface CatalogProps extends CatalogResultsProps {
   /** title that appears on top of the link lists */
   title?: string;
   /** display alternate title */
   alternateTitleDisplay?: boolean;
+  /** optional view for pagination */
+  pagination?: PaginationFn;
 }


### PR DESCRIPTION
(Separate this out from #69 for better parity)

Based on the discussion from https://github.com/thoughtindustries/helium/pull/69 , add a new render prop to `Catalog` component to allow customization of the pagination component. Make this an optional prop, a default pagination component will be rendered if this prop is not set.