### PR TITLE
Change initPageContext reference in Cloudflare Worker

### DIFF
--- a/tooling/helium-server/worker/init-page-context.js
+++ b/tooling/helium-server/worker/init-page-context.js
@@ -1,0 +1,73 @@
+import fetch from 'isomorphic-unfetch';
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { BatchHttpLink } from '@apollo/client/link/batch-http';
+import { createPersistedQueryLink } from '@apollo/client/link/persisted-queries';
+import { setContext } from '@apollo/client/link/context';
+
+export default async function initPageContext(
+  url,
+  renderPage,
+  currentUser,
+  appearance,
+  heliumEndpoint,
+  isProduction,
+  sha256,
+  authToken,
+  port
+) {
+  const apolloClient = makeApolloServerClient(
+    heliumEndpoint,
+    isProduction,
+    sha256,
+    authToken,
+    port
+  );
+
+  const pageContextInit = {
+    url,
+    apolloClient,
+    heliumEndpoint,
+    appearance,
+    currentUser,
+    isProduction,
+    authToken
+  };
+
+  const pageContext = await renderPage(pageContextInit);
+
+  return pageContext;
+}
+
+function makeApolloServerClient(heliumEndpoint, isProduction, sha256, authToken, port) {
+  let link = setContext((_, { headers }) => {
+    return {
+      headers: {
+        ...headers,
+        authToken: authToken ? `${authToken}` : ''
+      }
+    };
+  });
+
+  if (isProduction && sha256) {
+    link = link.concat(
+      createPersistedQueryLink({
+        sha256
+      })
+    );
+  }
+
+  const endpoint = !isProduction && port ? `http://localhost:${port}/graphql` : heliumEndpoint;
+
+  link = link.concat(
+    new BatchHttpLink({
+      uri: endpoint,
+      fetch
+    })
+  );
+
+  return new ApolloClient({
+    ssrMode: true,
+    link: link,
+    cache: new InMemoryCache()
+  });
+}

--- a/tooling/helium-server/worker/ssr.js
+++ b/tooling/helium-server/worker/ssr.js
@@ -2,7 +2,7 @@ import { createPageRenderer } from 'vite-plugin-ssr';
 import jwt_decode from 'jwt-decode';
 // We load `importBuild.js` so that the worker code can be bundled into a single file
 import '../dist/server/importBuild.js';
-import { initPageContext } from '@thoughtindustries/helium-server';
+import initPageContext from './init-page-context';
 import tiConfig from 'tiConfig';
 
 export { handleSsr };


### PR DESCRIPTION
@chrisvariety Rolled back changes piece by piece but still found myself running into the unresolved module issue and discovered it was the way wrangler was using webpack to bundle up the worker, specifically the compiled version of `@thoughtindustries/helium-server/init-page-context`. Creating a plain JS version resolves the issue locally (running `wrangler dev`). 

Can test implementing an `esbuild` version, but that comes with its own issues, namely `process.env.*` needing to be defined when building the worker, which would require changes to the deployment script, so felt this approach was more timely for now.