### PR TITLE
Retrieve user jwt from header instead of query param when handling requests in Cloudflare Worker

### DIFF
--- a/tooling/helium-server/worker/index.js
+++ b/tooling/helium-server/worker/index.js
@@ -53,7 +53,8 @@ async function handleFetchEvent(event) {
   if (!isAssetUrl(event.request.url)) {
     const { headers } = event.request;
     const authToken = headers.get('authToken') || null;
-    const response = await handleSsr(event.request.url, authToken);
+    const userAndAppearanceToken = headers.get('userAndAppearance') || null;
+    const response = await handleSsr(event.request.url, authToken, userAndAppearanceToken);
     if (response !== null) return response;
   }
   const response = await handleStaticAssets(event);

--- a/tooling/helium-server/worker/ssr.js
+++ b/tooling/helium-server/worker/ssr.js
@@ -36,9 +36,12 @@ const create =
 
 const sha256 = create('SHA-256');
 
-async function handleSsr(url, authToken = null) {
+async function handleSsr(url, authToken = null, userAndAppearanceToken = null) {
   const tiInstance = findTiInstance(INSTANCE_NAME);
-  const { currentUser, appearanceBlock } = decryptUserAndAppearance(url, tiInstance);
+  const { currentUser, appearanceBlock } = decryptUserAndAppearance(
+    userAndAppearanceToken,
+    tiInstance
+  );
   const pageContext = await initPageContext(
     url,
     renderPage,
@@ -64,24 +67,20 @@ async function handleSsr(url, authToken = null) {
   }
 }
 
-function decryptUserAndAppearance(url, tiInstance) {
+function decryptUserAndAppearance(userAndAppearanceToken, tiInstance) {
   let currentUser = {};
   let appearanceBlock = {};
 
-  const urlObj = new URL(url);
-  if (urlObj.searchParams && urlObj.searchParams.get('jwt')) {
-    if (tiInstance && tiInstance.apiKey) {
-      const signedJwt = urlObj.searchParams.get('jwt');
-      const decryptedJWT = jwt_decode(signedJwt);
+  if (userAndAppearanceToken && tiInstance && tiInstance.apiKey) {
+    const decryptedJWT = jwt_decode(userAndAppearanceToken);
 
-      if (decryptedJWT) {
-        if (decryptedJWT.currentUser) {
-          currentUser = decryptedJWT.currentUser;
-        }
+    if (decryptedJWT) {
+      if (decryptedJWT.currentUser) {
+        currentUser = decryptedJWT.currentUser;
+      }
 
-        if (decryptedJWT.appearanceBlock) {
-          appearanceBlock = decryptedJWT.appearanceBlock;
-        }
+      if (decryptedJWT.appearanceBlock) {
+        appearanceBlock = decryptedJWT.appearanceBlock;
       }
     }
   }


### PR DESCRIPTION
Ref: https://github.com/thoughtindustries/ti/pull/7544

When passing the jwt as a query param, it gets passed down to child components via the url handler/page context, resulting in some malformed URLs. Handling it as a header instead should be cleaner.