### PR TITLE
feat: update cli authentication operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45132,7 +45132,7 @@
         "@thoughtindustries/navigation-bar": "^1.1.1",
         "@types/node": "^17.0.23",
         "@types/react": "^17.0.39",
-        "clsx": "*",
+        "clsx": "^1.2.1",
         "concurrently": "^7.0.0",
         "cross-env": "^7.0.3",
         "graphql": "^16.0.0",


### PR DESCRIPTION
Closes CLM-5218

Currently, the cli authentication operation validates given TI instance against endpoint `/incoming/v2/ping`. Change it to validate against helium endpoint over `CompanyDetails` query.

To verify, not sure what's the best way to verify the changes outside the context of helium demo app. Did the following sanity checks:

- in helium repo, verify the cli authentication operation directly with both a valid and an invalid api key. 
- in stackblitz project referencing the workspace `tooling/cli` (could follow [this link](https://stackblitz.com/fork/github/thoughtindustries/helium/tree/update-cli-auth/tooling/cli)), verify the cli authentication operation directly with a combination of feature flag `Allow Stackblitz for Helium`, and valid/invalid api keys. It is interesting to note that when the feature is on, using an invalid api key would trigger a CORS error in stackblitz.