### PR TITLE
feat: use local catalog error component

### DIFF
--- a/tooling/template-base/components/CatalogAndAggreg/CatalogAndAggregation.tsx
+++ b/tooling/template-base/components/CatalogAndAggreg/CatalogAndAggregation.tsx
@@ -1,9 +1,8 @@
 import React, { FC, useMemo } from 'react';
-import { CatalogProps } from '@thoughtindustries/catalog/src/types';
 import CatalogAggregations from './Aggregations';
-import CatalogError from '@thoughtindustries/catalog/src/catalog-error';
+import CatalogError from './CatalogError';
 import CatalogResults from './CatalogResults';
-import { CatalogProvider } from '@thoughtindustries/catalog';
+import { CatalogProvider, CatalogProps } from '@thoughtindustries/catalog';
 import { usePageContext } from '../../renderer/usePageContext';
 
 const CatalogAndAggregation: FC<CatalogProps> = ({

--- a/tooling/template-base/components/CatalogAndAggreg/CatalogError.tsx
+++ b/tooling/template-base/components/CatalogAndAggreg/CatalogError.tsx
@@ -1,0 +1,16 @@
+import React, { ReactElement } from 'react';
+import { useCatalog } from '@thoughtindustries/catalog';
+
+const CatalogError = ({ children }: { children: ReactElement }): JSX.Element => {
+  const { params } = useCatalog();
+  const { error } = params;
+
+  if (error) {
+    return <>{error}</>;
+  }
+
+  return children;
+};
+
+CatalogError.displayName = 'CatalogError';
+export default CatalogError;


### PR DESCRIPTION
Unticketed

An issue occurred when loading catalog page of the helium app. The page did quick flash from content to blank page and the console shows error about missing catalog context. Can repro this in helium app script, but not able to repro from helium template base workspace.

think the culprit might lie in how vite scanned and bundled the assets when importing from package files source directly (instead of from the package entry point). As noted the console error for missing Catalog Context in the browser, it shows the error stack from `CatalogProvider` (vite bundled asset) to `CatalogError` (not bundled by vite).

This could cause the `CatalogError` to access a different context object than the one populated by `CatalogProvider`. changes to fix this: Instead of importing from package files source directly for CatalogError (change `import CatalogError from '@thoughtindustries/catalog/src/catalog-error';`), we could clone this component in the template base.