### PR TITLE
fix: remove closing angle bracket from regex match

### DIFF
--- a/tooling/helium-server/worker/ssr.js
+++ b/tooling/helium-server/worker/ssr.js
@@ -91,8 +91,8 @@ function decryptUserAndAppearance(userAndAppearanceToken, tiInstance) {
 function resolveAssetUrls(url, htmlString) {
   const urlObj = new URL(url);
   const resolvedString = htmlString.replace(
-    / (src|href)="\/assets\/(.*?)">/g,
-    ` $1="${urlObj.origin}/assets/$2">`
+    / (src|href)="\/assets\/(.*?)"/g,
+    ` $1="${urlObj.origin}/assets/$2"`
   );
   return resolvedString;
 }


### PR DESCRIPTION
In `@thoughtindustries/helium-server`, remove the closing angle bracket from regex pattern/replace in `resolveAssetUrls` to account for additional attributes in elements.