### PR TITLE
fix: set custom cache key for UserAwardCount type objects

### DIFF
--- a/tooling/helium-server/src/utilities/init-page-context.ts
+++ b/tooling/helium-server/src/utilities/init-page-context.ts
@@ -91,6 +91,12 @@ function makeApolloServerClient(
   return new ApolloClient({
     ssrMode: true,
     link: link as any,
-    cache: new InMemoryCache()
+    cache: new InMemoryCache({
+      typePolicies: {
+        UserAwardCount: {
+          keyFields: ['id', 'label', 'count']
+        }
+      }
+    })
   });
 }


### PR DESCRIPTION
Closes CLM-6860

The `UserAwardCount` returns an object with the associated `awardType.id` as its `id` instead of the `id` of the `award` itself. If the same `awardType` is used across multiple courses, then requests that contain multiple `UserCourseAwardCounts` can have returns that are cached versions of the first return due to Apollo Client defaulting to the `objectType`'s `id` as the cache key.

This change modifies the type policy to use `['id', 'label', 'count']` as the cache key instead.

Additional Reading: https://www.apollographql.com/docs/react/caching/cache-configuration/#customizing-cache-ids