### PR TITLE
feat: add dist tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47372,6 +47372,10 @@
       },
       "devDependencies": {
         "@apollo/client": "^3.5.8"
+      },
+      "engines": {
+        "node": ">=16.18.1",
+        "npm": ">=8.19.2"
       }
     },
     "tooling/cli/node_modules/ansi-styles": {
@@ -47482,6 +47486,10 @@
       "bin": {
         "create-helium": "index.js",
         "create-helium-app": "index.js"
+      },
+      "engines": {
+        "node": ">=16.18.1",
+        "npm": ">=8.19.2"
       }
     },
     "tooling/create-helium-app/node_modules/ansi-styles": {
@@ -47625,6 +47633,10 @@
       "devDependencies": {
         "@types/express": "^4.17.14",
         "tsup": "^5.11.13"
+      },
+      "engines": {
+        "node": ">=16.18.1",
+        "npm": ">=8.19.2"
       }
     },
     "tooling/helium-server/node_modules/@vitejs/plugin-react": {

--- a/packages/cart/package.json
+++ b/packages/cart/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/contact-block/package.json
+++ b/packages/contact-block/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/dashboard-stats/package.json
+++ b/packages/dashboard-stats/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/featured-content/package.json
+++ b/packages/featured-content/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/hero/package.json
+++ b/packages/hero/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/link-lists/package.json
+++ b/packages/link-lists/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/navigation-bar/package.json
+++ b/packages/navigation-bar/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/testimonial/package.json
+++ b/packages/testimonial/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/user/package.json
+++ b/packages/user/package.json
@@ -7,7 +7,8 @@
     "generate": "graphql-codegen --config codegen.yml"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "repository": {
     "type": "git",

--- a/packages/video-player/package.json
+++ b/packages/video-player/package.json
@@ -7,7 +7,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -10,7 +10,8 @@
     "helium": "lib/index.js"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "dependencies": {
     "@graphql-tools/graphql-tag-pluck": "^7.1.3",

--- a/tooling/template-base/package.json
+++ b/tooling/template-base/package.json
@@ -14,7 +14,8 @@
     "build:vite": "vite build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "dependencies": {
     "@apollo/client": "^3.7.0",


### PR DESCRIPTION
Closes CLM-6029

Since the release for CLM-6029, we now have packages targeting different distribution tags (`latest` vs `beta`) in the monorepo. To simplify the updated package release process, we could add `tag` under `publishConfig` for pre-released packages, the default `tag` will target `latest` for stable releases.