### PR TITLE
feat: add cli function to fetch deploy log when deployment fails

### DIFF
--- a/tooling/cli/lib/command-modules/authenticate.js
+++ b/tooling/cli/lib/command-modules/authenticate.js
@@ -1,13 +1,7 @@
-const inquirer = require('inquirer');
 const { INSTANCE_QUESTIONS } = require('../prompts');
 const { isInstance } = require('../validations');
 const { initProject } = require('../file-generators');
-
-const promptQuestions = async questions => {
-  return new Promise((resolve, reject) => {
-    inquirer.prompt(questions).then(resolve).catch(reject);
-  });
-};
+const { promptQuestions } = require('../helpers/prompts');
 
 const gatherInstances = async (instances = []) => {
   const newInstanceAnswers = await promptQuestions(INSTANCE_QUESTIONS);

--- a/tooling/cli/lib/command-modules/deploy.js
+++ b/tooling/cli/lib/command-modules/deploy.js
@@ -56,7 +56,7 @@ exports.handler = function (argv) {
       const deployLogScriptPath = path.resolve(__dirname, './../deployment-log.js');
       const deployLogProcess = fork(deployLogScriptPath, undefined, { env });
 
-      deployLogProcess.send({ jobId: message.jobId });
+      deployLogProcess.send(message);
 
       /**
        * It expects message from deploy log process when fetching batch of deployment job log completes.

--- a/tooling/cli/lib/command-modules/deploy.js
+++ b/tooling/cli/lib/command-modules/deploy.js
@@ -1,5 +1,13 @@
 const childProcess = require('child_process');
 const path = require('path');
+const inquirer = require('inquirer');
+const { DEPLOYMENT_LOG_FETCH_QUESTION, DEPLOYMENT_LOG_FETCH_MORE_QUESTION } = require('../prompts');
+
+const promptQuestions = async questions => {
+  return new Promise((resolve, reject) => {
+    inquirer.prompt(questions).then(resolve).catch(reject);
+  });
+};
 
 exports.command = 'deploy <instance> [-k]';
 exports.describe = 'Compile and deploy a specified instance';
@@ -19,19 +27,77 @@ exports.builder = cmd => {
 };
 
 exports.handler = function (argv) {
-  const exec = childProcess.exec;
+  const { fork } = childProcess;
   const env = {
     ...process.env,
     INSTANCE_NAME: argv.instance,
     NODE_TLS_REJECT_UNAUTHORIZED: argv.insecure ? '0' : '1'
   };
 
+  // Process for running deployment - 1-way IPC from child to parent
   const deployScriptPath = path.resolve(__dirname, './../deploy.js');
-  const deployProcess = exec(`node ${deployScriptPath}`, { env });
+  const deployProcess = fork(deployScriptPath, undefined, { env });
 
-  deployProcess.stdout.pipe(process.stdout);
-  deployProcess.stderr.pipe(process.stderr);
+  /**
+   * It expects message from deploy process when deployment job returns 'FAILURE'.
+   * The message body should include jobId.
+   * In the message handler:
+   * - prompt user question to fetch deployment job log
+   * - manually disconnect from deploy process
+   * - fork new process to fetch deployment job
+   */
+  deployProcess.on('message', async message => {
+    console.log('>>> deployProcess message received on parent', message);
+    const fetchLogsAnswers = await promptQuestions([DEPLOYMENT_LOG_FETCH_QUESTION]);
+    deployProcess.disconnect();
+    if (fetchLogsAnswers.shouldFetchLogs) {
+      // Process for deployment log - 2-way IPC between child and parent
+      const deployLogScriptPath = path.resolve(__dirname, './../deployment-log.js');
+      const deployLogProcess = fork(deployLogScriptPath, undefined, { env });
 
+      deployLogProcess.send({ jobId: message.jobId });
+
+      /**
+       * It expects message from deploy log process when fetching batch of deployment job log completes.
+       * The message body should include jobId and token to fetch next batch of log.
+       * In the message handler:
+       * - prompt user question to fetch more deployment job log
+       * - if user answers 'No', manually disconnect from deploy log process
+       * - if user answers 'Yes', forward message to deploy log process to fetch next batch of log
+       */
+      deployLogProcess.on('message', async msg => {
+        console.log('>>> deployLogProcess message received on parent', msg);
+        const fetchMoreLogsAnswers = await promptQuestions([DEPLOYMENT_LOG_FETCH_MORE_QUESTION]);
+        if (fetchMoreLogsAnswers.shouldFetchMoreLogs) {
+          deployLogProcess.send(msg);
+        } else {
+          deployLogProcess.disconnect();
+        }
+      });
+      deployLogProcess.on('disconnect', () => {
+        console.log('>>> deployLogProcess IPC disconnected on parent');
+      });
+      deployLogProcess.on('error', error => {
+        console.log('>>> deployLogProcess error received on parent', error);
+      });
+      deployLogProcess.on('exit', code => {
+        console.log('>>> deployLogProcess exit received on parent with code', code);
+      });
+      deployLogProcess.on('close', code => {
+        console.log('>>> deployLogProcess close received on parent with code', code);
+      });
+    }
+  });
+
+  deployProcess.on('disconnect', () => {
+    console.log('>>> deployProcess IPC disconnected on parent');
+  });
+  deployProcess.on('error', error => {
+    console.log('>>> deployProcess error received on parent', error);
+  });
+  deployProcess.on('close', code => {
+    console.log('>>> deployProcess close received on parent with code', code);
+  });
   deployProcess.on('exit', code =>
     console.log(`deployProcess process exited with code ${code.toString()}`)
   );

--- a/tooling/cli/lib/command-modules/deploy.js
+++ b/tooling/cli/lib/command-modules/deploy.js
@@ -40,11 +40,12 @@ exports.handler = function (argv) {
 
   /**
    * It expects message from deploy process when deployment job returns 'FAILURE'.
-   * The message body should include jobId.
+   * The message body should include jobId and TI instance object.
    * In the message handler:
    * - prompt user question to fetch deployment job log
    * - manually disconnect from deploy process
-   * - fork new process to fetch deployment job
+   * - if user answers 'Yes', fork new process to fetch deployment job and forward
+   * message to trigger fetch
    */
   deployProcess.on('message', async message => {
     console.log('>>> deployProcess message received on parent', message);

--- a/tooling/cli/lib/command-modules/deploy.js
+++ b/tooling/cli/lib/command-modules/deploy.js
@@ -48,7 +48,6 @@ exports.handler = function (argv) {
    * message to trigger fetch
    */
   deployProcess.on('message', async message => {
-    console.log('>>> deployProcess message received on parent', message);
     const fetchLogsAnswers = await promptQuestions([DEPLOYMENT_LOG_FETCH_QUESTION]);
     deployProcess.disconnect();
     if (fetchLogsAnswers.shouldFetchLogs) {
@@ -67,7 +66,6 @@ exports.handler = function (argv) {
        * - if user answers 'Yes', forward message to deploy log process to fetch next batch of log
        */
       deployLogProcess.on('message', async msg => {
-        console.log('>>> deployLogProcess message received on parent', msg);
         const fetchMoreLogsAnswers = await promptQuestions([DEPLOYMENT_LOG_FETCH_MORE_QUESTION]);
         if (fetchMoreLogsAnswers.shouldFetchMoreLogs) {
           deployLogProcess.send(msg);
@@ -75,30 +73,13 @@ exports.handler = function (argv) {
           deployLogProcess.disconnect();
         }
       });
-      deployLogProcess.on('disconnect', () => {
-        console.log('>>> deployLogProcess IPC disconnected on parent');
-      });
-      deployLogProcess.on('error', error => {
-        console.log('>>> deployLogProcess error received on parent', error);
-      });
+
       deployLogProcess.on('exit', code => {
-        console.log('>>> deployLogProcess exit received on parent with code', code);
-      });
-      deployLogProcess.on('close', code => {
-        console.log('>>> deployLogProcess close received on parent with code', code);
+        console.log(`deployLogProcess process exited with code ${code.toString()}`);
       });
     }
   });
 
-  deployProcess.on('disconnect', () => {
-    console.log('>>> deployProcess IPC disconnected on parent');
-  });
-  deployProcess.on('error', error => {
-    console.log('>>> deployProcess error received on parent', error);
-  });
-  deployProcess.on('close', code => {
-    console.log('>>> deployProcess close received on parent with code', code);
-  });
   deployProcess.on('exit', code =>
     console.log(`deployProcess process exited with code ${code.toString()}`)
   );

--- a/tooling/cli/lib/command-modules/deploy.js
+++ b/tooling/cli/lib/command-modules/deploy.js
@@ -1,13 +1,7 @@
 const childProcess = require('child_process');
 const path = require('path');
-const inquirer = require('inquirer');
+const { promptQuestions } = require('../helpers/prompts');
 const { DEPLOYMENT_LOG_FETCH_QUESTION, DEPLOYMENT_LOG_FETCH_MORE_QUESTION } = require('../prompts');
-
-const promptQuestions = async questions => {
-  return new Promise((resolve, reject) => {
-    inquirer.prompt(questions).then(resolve).catch(reject);
-  });
-};
 
 exports.command = 'deploy <instance> [-k]';
 exports.describe = 'Compile and deploy a specified instance';

--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -375,7 +375,7 @@ async function checkDeploymentJobStatus(instance, jobId, key, atomsScriptHash, a
         if (resObj.data) {
           resolve(resObj.data.HeliumDeploymentStatus);
         } else {
-          const err = resObj.errors[0];
+          const err = resObj.errors;
           reject(err.message);
         }
       })

--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -57,22 +57,16 @@ const JOB_QUERY = /* GraphQL */ `
   }
 `;
 
-class CustomError extends Error {
-  constructor(message) {
+class DeploymentError extends Error {
+  #payload;
+  constructor(message, payload) {
     super(message);
     // Ensure the name of this error is the same as the class name
     this.name = this.constructor.name;
-    // This clips the constructor invocation from the stack trace.
-    // It's not absolutely essential, but it does make the stack trace a little nicer.
-    //  @see Node.js reference (bottom)
-    Error.captureStackTrace(this, this.constructor);
+    this.#payload = { ...payload };
   }
-}
-
-class DeploymentError extends CustomError {
-  constructor(message, payload) {
-    super(message);
-    this.payload = { ...payload };
+  getPayload() {
+    return this.#payload;
   }
 }
 
@@ -132,7 +126,7 @@ class DeploymentError extends CustomError {
   .catch(err => {
     console.error('>>> Error deploying: ', err);
     if (err instanceof DeploymentError) {
-      process.send(err.payload);
+      process.send(err.getPayload());
     } else {
       process.exit(1);
     }

--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -126,10 +126,7 @@ class DeploymentError extends CustomError {
 
     await poll(fetchStatus, processing, 3000);
   } catch (e) {
-    if (e instanceof DeploymentError) {
-      throw e;
-    }
-    throw new Error(e);
+    throw e;
   }
 })()
   .then(() => {
@@ -144,6 +141,11 @@ class DeploymentError extends CustomError {
       process.exit(1);
     }
   });
+
+// Add message event handler to keep the process running until manually closed
+process.on('message', message => {
+  console.log('>>> Deploy process receive message', message);
+});
 
 async function buildProject(hasAtoms) {
   return new Promise((resolve, reject) => {
@@ -373,7 +375,7 @@ async function checkDeploymentJobStatus(instance, jobId, key, atomsScriptHash, a
         if (resObj.data) {
           resolve(resObj.data.HeliumDeploymentStatus);
         } else {
-          const err = resObj.errors;
+          const err = resObj.errors[0];
           reject(err.message);
         }
       })

--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -118,7 +118,7 @@ class DeploymentError extends CustomError {
 
     const processing = result => {
       if (result === 'FAILED') {
-        throw new DeploymentError('Batch deployment failed', { jobId: batchJobId });
+        throw new DeploymentError('Batch deployment failed', { jobId: batchJobId, instance });
       }
 
       return result !== 'SUCCEEDED';

--- a/tooling/cli/lib/deployment-log.js
+++ b/tooling/cli/lib/deployment-log.js
@@ -70,7 +70,12 @@ async function* deploymentLogsGenerator(jobId, instance) {
     const chunk = events.map(({ timestamp, message }) => `(${timestamp}) ${message}\n`).join('');
     yield chunk;
 
-    if (!events.length || !nextForwardTokenNew || nextForwardTokenNew === nextForwardToken) {
+    if (
+      !events.length ||
+      events.length < BATCH_LOG_LIMIT ||
+      !nextForwardTokenNew ||
+      nextForwardTokenNew === nextForwardToken
+    ) {
       hasMoreLog = false;
     } else {
       nextForwardToken = nextForwardTokenNew;

--- a/tooling/cli/lib/deployment-log.js
+++ b/tooling/cli/lib/deployment-log.js
@@ -1,7 +1,6 @@
 const { instanceEndpoint } = require('./helpers/urls');
 const fetch = require('isomorphic-unfetch');
 
-const INSTANCE_NAME = process.env.INSTANCE_NAME;
 const BATCH_LOGS_QUERY = /* GraphQL */ `
   query HeliumDeploymentLogQuery($jobId: ID!, $filters: HeliumDeploymentLogFiltersInput) {
     HeliumDeploymentLog(jobId: $jobId, filters: $filters) {
@@ -45,7 +44,7 @@ function fetchDeploymentLogs(instance, jobId, filters) {
   });
 }
 
-process.on('message', async ({ jobId, nextForwardToken }) => {
+process.on('message', async ({ jobId, nextForwardToken, instance }) => {
   try {
     const filters = {
       limit: BATCH_LOG_LIMIT,
@@ -53,7 +52,7 @@ process.on('message', async ({ jobId, nextForwardToken }) => {
       nextToken: nextForwardToken
     };
     const { events, nextForwardToken: nextForwardTokenNew } = await fetchDeploymentLogs(
-      INSTANCE_NAME,
+      instance,
       jobId,
       filters
     );
@@ -68,7 +67,7 @@ process.on('message', async ({ jobId, nextForwardToken }) => {
       process.exit(0);
     } else {
       // Report back to parent process
-      process.send({ jobId, nextForwardToken: nextForwardTokenNew });
+      process.send({ jobId, nextForwardToken: nextForwardTokenNew, instance });
     }
   } catch (err) {
     console.error('>>> Error fetching deployment log: ', err);

--- a/tooling/cli/lib/deployment-log.js
+++ b/tooling/cli/lib/deployment-log.js
@@ -1,0 +1,77 @@
+const { instanceEndpoint } = require('./helpers/urls');
+const fetch = require('isomorphic-unfetch');
+
+const INSTANCE_NAME = process.env.INSTANCE_NAME;
+const BATCH_LOGS_QUERY = /* GraphQL */ `
+  query HeliumDeploymentLogQuery($jobId: ID!, $filters: HeliumDeploymentLogFiltersInput) {
+    HeliumDeploymentLog(jobId: $jobId, filters: $filters) {
+      events {
+        timestamp
+        message
+      }
+      nextForwardToken
+    }
+  }
+`;
+const BATCH_LOG_LIMIT = 10000;
+
+function fetchDeploymentLogs(instance, jobId, filters) {
+  return new Promise((resolve, reject) => {
+    const endpoint = instanceEndpoint(instance);
+    const options = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: BATCH_LOGS_QUERY,
+        variables: { jobId, filters }
+      })
+    };
+
+    fetch(endpoint, options)
+      .then(r => r.json())
+      .then(res => {
+        const resObj = res;
+
+        if (resObj.data) {
+          resolve(resObj.data.HeliumDeploymentLog);
+        } else {
+          const err = resObj.errors[0];
+          reject(err.message);
+        }
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+}
+
+process.on('message', async ({ jobId, nextForwardToken }) => {
+  try {
+    const filters = {
+      limit: BATCH_LOG_LIMIT,
+      startFromHead: true,
+      nextToken: nextForwardToken
+    };
+    const { events, nextForwardToken: nextForwardTokenNew } = await fetchDeploymentLogs(
+      INSTANCE_NAME,
+      jobId,
+      filters
+    );
+    events.forEach(({ timestamp, message }) => console.log(`>>> (${timestamp}) ${message}`));
+    if (
+      !events.length ||
+      events.length < BATCH_LOG_LIMIT ||
+      !nextForwardTokenNew ||
+      nextForwardTokenNew === nextForwardToken
+    ) {
+      console.log('>>> You have reached the end of the deployment log.');
+      process.exit(0);
+    } else {
+      // Report back to parent process
+      process.send({ jobId, nextForwardToken: nextForwardTokenNew });
+    }
+  } catch (err) {
+    console.error('>>> Error fetching deployment log: ', err);
+    process.exit(1);
+  }
+});

--- a/tooling/cli/lib/helpers/prompts.js
+++ b/tooling/cli/lib/helpers/prompts.js
@@ -1,0 +1,9 @@
+const inquirer = require('inquirer');
+
+const promptQuestions = async questions => {
+  return new Promise((resolve, reject) => {
+    inquirer.prompt(questions).then(resolve).catch(reject);
+  });
+};
+
+module.exports = { promptQuestions };

--- a/tooling/cli/lib/prompts.js
+++ b/tooling/cli/lib/prompts.js
@@ -32,6 +32,20 @@ const INSTANCE_QUESTIONS = [
   }
 ];
 
+const DEPLOYMENT_LOG_FETCH_QUESTION = {
+  type: 'confirm',
+  name: 'shouldFetchLogs',
+  message: 'Would you like to fetch logs for the deployment?'
+};
+
+const DEPLOYMENT_LOG_FETCH_MORE_QUESTION = {
+  type: 'confirm',
+  name: 'shouldFetchMoreLogs',
+  message: 'Would you like to fetch next batch of logs for the deployment?'
+};
+
 module.exports = {
-  INSTANCE_QUESTIONS
+  INSTANCE_QUESTIONS,
+  DEPLOYMENT_LOG_FETCH_QUESTION,
+  DEPLOYMENT_LOG_FETCH_MORE_QUESTION
 };

--- a/tooling/cli/lib/prompts.js
+++ b/tooling/cli/lib/prompts.js
@@ -38,14 +38,7 @@ const DEPLOYMENT_LOG_FETCH_QUESTION = {
   message: 'Would you like to fetch logs for the deployment?'
 };
 
-const DEPLOYMENT_LOG_FETCH_MORE_QUESTION = {
-  type: 'confirm',
-  name: 'shouldFetchMoreLogs',
-  message: 'Would you like to fetch next batch of logs for the deployment?'
-};
-
 module.exports = {
   INSTANCE_QUESTIONS,
-  DEPLOYMENT_LOG_FETCH_QUESTION,
-  DEPLOYMENT_LOG_FETCH_MORE_QUESTION
+  DEPLOYMENT_LOG_FETCH_QUESTION
 };


### PR DESCRIPTION
Closes CLM-7218

## Changes

This is a draft to add cli function to fetch deploy log when deployment fails. Referring to the current structure, we handle the deploy cli command in the command module and spawns a shell to run the deploy script. Since deployment could fail at different stage and we want to only prompt user for fetching the log when batch job fails, might consider a communication between the deploy command module and spawned deploy process. 

I am using the following structure to establish communications between processes:

- parent process: the deploy cli command module (`./lib/command-modules/deploy.js`) is responsible for the cli command declaration, orchestrating spawning/closing child processes, and prompting user questions.
- child deployment process: the spawned deploy process (`./lib/deploy.js`) is responsible for running the deployment, and conditionally closing own process or sending message to the parent process when batch job fails.
- child deployment log process: the spawned deploy log process (`./lib/deployment-log.js`) is responsible for running the deployment log fetch task, streaming full log events to local file system, and closing own process once task is complete.

### Workflow when deployment fails

When deployment fails, the communication flow looks something like below:

1. parent process spawns child deployment process with ipc established
2. child deployment process sends message when deployment fails, message body includes info about TI instance and failed batch job id
3. upon receiving message from child deployment process, parent process prompts user if they want to fetch deployment log. after user answers the question, parent process closes child deployment process. If user answers 'yes', parent process spawns child deployment log process with ipc establisted and forward the message body to trigger the fetch.
4. upon receiving message from parent process, child deployment log process triggers the full log fetch and stream log events to local file system. Once the task completes, it closes own process

### Verifications

this change would only apply to the case when batch job fails. did the following sanity checks:

1. successful deployment should behave as is
2. failed deployment due to any errors before batch job fails should behave as is
3. failed batch job should prompt user to fetch deployment log
  - when user answers 'no', all processes should be closed
  - when user answers 'yes', all log events should be saved to local file system (if less than 10k events) and then all processes should be closed afterwards
  - when user answers 'yes' and a smaller batch size is used to trigger multiple graphql calls for the log fetch. Process will simultanously stream log events to local file system until the fetch completes. When the end of the list is reached, all processes should be closed. 