### PR TITLE
CLM-7704 Set duplex option when using stream as body in request

### DIFF
--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -280,7 +280,8 @@ function uploadToS3(filePath, fileSize, policyData, tryCount = 0) {
     const options = {
       method: 'PUT',
       body: createReadStream(filePath),
-      headers: { 'Content-Length': fileSize }
+      headers: { 'Content-Length': fileSize },
+      duplex: 'half'
     };
 
     fetch(signedUrl, options)


### PR DESCRIPTION
Closes CLM-7704

Sets `duplex` option when using a stream for request body.

Add'l Reading: https://github.com/nodejs/node/issues/46221