### PR TITLE
fix: move content paths to template tailwind config

### DIFF
--- a/tooling/tailwind-preset/src/index.ts
+++ b/tooling/tailwind-preset/src/index.ts
@@ -4,12 +4,6 @@ module.exports = {
   corePlugins: {
     visibility: false
   },
-  content: [
-    './atoms/**/*.{js,jsx,ts,tsx}',
-    './pages/**/*.{js,jsx,ts,tsx}',
-    './components/**/*.{js,jsx,ts,tsx}',
-    './dist/**/*.{js,jsx,ts,tsx}'
-  ],
   theme: {
     screens: {
       sm: '640px',

--- a/tooling/template-base-essentials/tailwind.config.js
+++ b/tooling/template-base-essentials/tailwind.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  presets: [require('@thoughtindustries/helium-tailwind-preset')]
+  presets: [require('@thoughtindustries/helium-tailwind-preset')],
+  content: [
+    './atoms/**/*.{js,jsx,ts,tsx}',
+    './pages/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}',
+    './dist/**/*.{js,jsx,ts,tsx}'
+  ]
 };

--- a/tooling/template-base/tailwind.config.js
+++ b/tooling/template-base/tailwind.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  presets: [require('@thoughtindustries/helium-tailwind-preset')]
+  presets: [require('@thoughtindustries/helium-tailwind-preset')],
+  content: [
+    './atoms/**/*.{js,jsx,ts,tsx}',
+    './pages/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}',
+    './dist/**/*.{js,jsx,ts,tsx}'
+  ]
 };


### PR DESCRIPTION
Closes CLM-8429

Paths aren't relative to `tailwind.config.js`. While a `relative` option was added in v3.2, if a user decides to specify their own `content` directory, tailwindcss's preset behavior will overwrite the `content` specified in our preset.