### PR TITLE
fix: batched queries compatibility issue setting user in local dev

### DIFF
--- a/tooling/helium-server/src/server/server.ts
+++ b/tooling/helium-server/src/server/server.ts
@@ -54,13 +54,18 @@ export default async function setupHeliumServer(root: string, viteDevServer: any
         reqHeaders[COOKIE_OR_HEADER_NAME_AUTHTOKEN] ||
         reqHeaders[COOKIE_OR_HEADER_NAME_AUTHTOKEN.toLowerCase()];
       const headers: any = { 'Content-Type': 'application/json' };
+
       if (reqAuthToken) {
         headers[COOKIE_OR_HEADER_NAME_AUTHTOKEN] = reqAuthToken;
       } else if (!isProduction && tiInstance?.email) {
         // primarily for SSO-configured schools utilizing local delevopment,
         // as the auth cookie set via Thought Industries SSO flow will be set
         // for that domain and will not be included in requests coming from localhost
-        reqBody.user = tiInstance.email;
+        if (Array.isArray(reqBody)) {
+          reqBody.push({ user: tiInstance.email });
+        } else {
+          reqBody.user = tiInstance.email;
+        }
       }
 
       const options = {


### PR DESCRIPTION
Extends #198 

When testing the original PR, was using `/graphiql` which was sending the queries as single objects. Queries in components can be batched, in which case `user` was not being appended to `reqBody<Array>` correctly.