### PR TITLE
fix: allow use of config email when fetching user for page context

### DIFF
--- a/tooling/helium-server/src/server/server.ts
+++ b/tooling/helium-server/src/server/server.ts
@@ -109,15 +109,22 @@ export default async function setupHeliumServer(root: string, viteDevServer: any
 
     // fetch appearance (batch operation to fetch current user if applied)
     if (shouldFetchAppearance) {
-      const userAndAppearance = await fetchUserAndAppearance(tiInstance, requestCookieAuthToken);
+      const userAndAppearance = await fetchUserAndAppearance(
+        tiInstance,
+        requestCookieAuthToken,
+        isProduction
+      );
       currentUser = userAndAppearance.currentUser;
       appearanceBlock = userAndAppearance.appearanceBlock;
     }
 
     // fetch current user
-    const shouldFetchUser = !!requestCookieAuthToken && !Object.keys(currentUser).length;
+    const canUseConfigEmail = !isProduction && tiInstance.email;
+    const shouldFetchUser =
+      (!!requestCookieAuthToken || canUseConfigEmail) && !Object.keys(currentUser).length;
+
     if (shouldFetchUser) {
-      currentUser = await fetchUser(tiInstance, requestCookieAuthToken);
+      currentUser = await fetchUser(tiInstance, requestCookieAuthToken, isProduction);
     }
 
     const url = req.originalUrl;

--- a/tooling/helium-server/src/utilities/fetch-user-and-appearance.ts
+++ b/tooling/helium-server/src/utilities/fetch-user-and-appearance.ts
@@ -66,6 +66,11 @@ type FetchRequest = {
   options: RequestInit;
 };
 
+type QueryReqBody = {
+  query: string;
+  user?: string;
+};
+
 const composeFetchRequest = (tiInstance: TiInstance, authToken?: string): FetchRequest => {
   const requestHeaders: any = { 'Content-Type': 'application/json' };
   if (authToken) {
@@ -79,10 +84,17 @@ const composeFetchRequest = (tiInstance: TiInstance, authToken?: string): FetchR
   return { endpoint, options };
 };
 
-const fetchUser = async (tiInstance: TiInstance, authToken: string) => {
+const fetchUser = async (tiInstance: TiInstance, authToken?: string, isProduction = true) => {
   let currentUser = {};
 
   const { endpoint, options } = composeFetchRequest(tiInstance, authToken);
+
+  const body = { query: USER_QUERY } as QueryReqBody;
+
+  if (!authToken && !isProduction && tiInstance.email) {
+    body.user = tiInstance.email;
+  }
+
   options.body = JSON.stringify({
     query: USER_QUERY
   });
@@ -100,14 +112,22 @@ const fetchUser = async (tiInstance: TiInstance, authToken: string) => {
   return currentUser;
 };
 
-const fetchUserAndAppearance = async (tiInstance: TiInstance, authToken?: string) => {
+const fetchUserAndAppearance = async (
+  tiInstance: TiInstance,
+  authToken?: string,
+  isProduction = true
+) => {
   let currentUser = {};
   let appearanceBlock = {};
 
   const { endpoint, options } = composeFetchRequest(tiInstance, authToken);
-  options.body = JSON.stringify({
-    query: USER_AND_APPEARANCE_QUERY
-  });
+  const body = { query: USER_AND_APPEARANCE_QUERY } as QueryReqBody;
+
+  if (!authToken && !isProduction && tiInstance.email) {
+    body.user = tiInstance.email;
+  }
+
+  options.body = JSON.stringify(body);
 
   const userDataResponse = await fetch(endpoint, options).then(r => r.json());
 


### PR DESCRIPTION
Extends #202 

Prior fixes resolved setting the user for the Apollo context. This resolves the initial user request for passing `CurrentUser` to `PageContext`.