### PR TITLE
fix: add template-base-essentials to package.json files

### DIFF
--- a/tooling/create-helium-app/package.json
+++ b/tooling/create-helium-app/package.json
@@ -13,7 +13,8 @@
   "files": [
     "index.js",
     "scripts",
-    "template-base"
+    "template-base",
+    "template-base-essentials"
   ],
   "scripts": {
     "prepublishOnly": "node ./scripts/tmp-copy-template-from-tooling.js"


### PR DESCRIPTION
Unticketed; adds `template-base-essentials` to files included in published `create-helium-app` package.