### PR TITLE
CLM-8779-Replicate-Redirect-on-Dashboard-Page

### DIFF
--- a/tooling/helium-server/worker/ssr.js
+++ b/tooling/helium-server/worker/ssr.js
@@ -46,13 +46,18 @@ async function handleSsr(url, authToken = null, userAndAppearanceToken = null) {
     sha256,
     authToken
   );
-  const { httpResponse } = pageContext;
+
+  const { httpResponse, redirectTo } = pageContext;
 
   if (!httpResponse) {
     return null;
   } else {
     const { statusCode, body } = httpResponse;
     const headers = assembleHeaders(pageContext);
+
+    if (redirectTo) {
+      url = redirectTo;
+    }
 
     return new Response(resolveAssetUrls(url, body), {
       headers,


### PR DESCRIPTION
Expose redictTo from the pageContext in the ssr worker. Check if it is defined and if so, redirect to that url instead.