### PR TITLE
CLM-8852 Remove Hydration Error on Catalog Component

### DIFF
--- a/packages/catalog/__tests__/catalog.test.tsx
+++ b/packages/catalog/__tests__/catalog.test.tsx
@@ -646,9 +646,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            10
-                            )
+                            (10)
                           </span>
                         </a>
                       </li>
@@ -661,9 +659,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            20
-                            )
+                            (20)
                           </span>
                         </a>
                       </li>
@@ -715,9 +711,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            20
-                            )
+                            (20)
                           </span>
                         </a>
                       </li>
@@ -769,9 +763,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            30
-                            )
+                            (30)
                           </span>
                         </a>
                       </li>
@@ -784,9 +776,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            40
-                            )
+                            (40)
                           </span>
                         </a>
                       </li>
@@ -912,8 +902,7 @@ describe('@thoughtindustries/catalog', () => {
                                         />
                                       </svg>
                                     </i>
-                                     
-                                    course-add-to-queue
+                                     course-add-to-queue
                                   </span>
                                 </button>
                               </div>
@@ -931,17 +920,12 @@ describe('@thoughtindustries/catalog', () => {
                     >
                       <span>
                         Showing
-                         
                         <strong>
-                          1
-                          -
-                          48
+                           1-48 
                         </strong>
-                         
-                        of 
+                        of
                         <strong>
-                          100
-                           items
+                           100 items
                         </strong>
                       </span>
                     </div>
@@ -1487,9 +1471,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            10
-                            )
+                            (10)
                           </span>
                         </a>
                       </li>
@@ -1502,9 +1484,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            20
-                            )
+                            (20)
                           </span>
                         </a>
                       </li>
@@ -1556,9 +1536,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            20
-                            )
+                            (20)
                           </span>
                         </a>
                       </li>
@@ -1610,9 +1588,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            30
-                            )
+                            (30)
                           </span>
                         </a>
                       </li>
@@ -1625,9 +1601,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            40
-                            )
+                            (40)
                           </span>
                         </a>
                       </li>
@@ -1777,8 +1751,7 @@ describe('@thoughtindustries/catalog', () => {
                                           />
                                         </svg>
                                       </i>
-                                       
-                                      course-add-to-queue
+                                       course-add-to-queue
                                     </span>
                                   </button>
                                 </span>
@@ -1849,17 +1822,12 @@ describe('@thoughtindustries/catalog', () => {
                     >
                       <span>
                         Showing
-                         
                         <strong>
-                          1
-                          -
-                          48
+                           1-48 
                         </strong>
-                         
-                        of 
+                        of
                         <strong>
-                          100
-                           items
+                           100 items
                         </strong>
                       </span>
                     </div>
@@ -2251,9 +2219,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            10
-                            )
+                            (10)
                           </span>
                         </a>
                       </li>
@@ -2266,9 +2232,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            20
-                            )
+                            (20)
                           </span>
                         </a>
                       </li>
@@ -2320,9 +2284,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            20
-                            )
+                            (20)
                           </span>
                         </a>
                       </li>
@@ -2374,9 +2336,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            30
-                            )
+                            (30)
                           </span>
                         </a>
                       </li>
@@ -2389,9 +2349,7 @@ describe('@thoughtindustries/catalog', () => {
                           <span
                             class="text-xs text-gray-700 pl-1"
                           >
-                            (
-                            40
-                            )
+                            (40)
                           </span>
                         </a>
                       </li>
@@ -2544,8 +2502,7 @@ describe('@thoughtindustries/catalog', () => {
                                       />
                                     </svg>
                                   </i>
-                                   
-                                  course-add-to-queue
+                                   course-add-to-queue
                                 </span>
                               </button>
                             </div>
@@ -2562,17 +2519,12 @@ describe('@thoughtindustries/catalog', () => {
                     >
                       <span>
                         Showing
-                         
                         <strong>
-                          1
-                          -
-                          48
+                           1-48 
                         </strong>
-                         
-                        of 
+                        of
                         <strong>
-                          100
-                           items
+                           100 items
                         </strong>
                       </span>
                     </div>

--- a/packages/catalog/src/catalog-aggregations.tsx
+++ b/packages/catalog/src/catalog-aggregations.tsx
@@ -24,7 +24,7 @@ const AggregationBucket = ({ href, value, count }: AggregationBucketProps): JSX.
       className="inline-block leading-normal py-1.5 px-4 text-link hover:text-link-hover"
     >
       {value}
-      {count && <span className="text-xs text-gray-700 pl-1">({count})</span>}
+      {count && <span className="text-xs text-gray-700 pl-1">{`(${count})`}</span>}
     </a>
   </li>
 );

--- a/packages/catalog/src/variants/display-type-results/item-queue-button.tsx
+++ b/packages/catalog/src/variants/display-type-results/item-queue-button.tsx
@@ -52,16 +52,16 @@ const ItemQueueButton = ({
         <span className="flex items-center gap-x-1">
           <i className="inline-block w-3 h-3 text-green-600" aria-label="check">
             <CheckCircleIcon />
-          </i>{' '}
-          {t('course-added-to-queue')}
+          </i>
+          {` (${t('course-added-to-queue')})`}
         </span>
       )}
       {!wasAddedToQueue && (
         <span className="flex items-center gap-x-1">
           <i className="inline-block w-3 h-3" aria-label="plus">
             <PlusIcon />
-          </i>{' '}
-          {t('course-add-to-queue')}
+          </i>
+          {` ${t('course-add-to-queue')}`}
         </span>
       )}
     </button>

--- a/packages/catalog/src/variants/display-type-results/item-queue-button.tsx
+++ b/packages/catalog/src/variants/display-type-results/item-queue-button.tsx
@@ -53,7 +53,7 @@ const ItemQueueButton = ({
           <i className="inline-block w-3 h-3 text-green-600" aria-label="check">
             <CheckCircleIcon />
           </i>
-          {` (${t('course-added-to-queue')})`}
+          {` ${t('course-added-to-queue')}`}
         </span>
       )}
       {!wasAddedToQueue && (

--- a/packages/pagination/__tests__/pagination.test.tsx
+++ b/packages/pagination/__tests__/pagination.test.tsx
@@ -18,17 +18,12 @@ describe('@thoughtindustries/pagination', () => {
             >
               <span>
                 Showing
-                 
                 <strong>
-                  1
-                  -
-                  50
+                   1-50 
                 </strong>
-                 
-                of 
+                of
                 <strong>
-                  100
-                   items
+                   100 items
                 </strong>
               </span>
             </div>

--- a/packages/pagination/src/pagination.tsx
+++ b/packages/pagination/src/pagination.tsx
@@ -73,11 +73,7 @@ const Pagination = ({
     <div className="mx-2 my-4 flex flex-wrap-reverse items-center justify-between">
       <div className="mt-2 flex items-center justify-start">
         <span>
-          Showing{' '}
-          <strong>
-            {start}-{end}
-          </strong>{' '}
-          of <strong>{total} items</strong>
+          Showing<strong>{` ${start}-${end} `}</strong>of<strong>{` ${total} items`}</strong>
         </span>
       </div>
       {!!visiblePages.length && (


### PR DESCRIPTION
Closes CLM-8852

Hydration mismatch was appearing when catalog component was being rendered. This was caused by issues with white space and code formatting. This has been resolved by computing the string instead. 

This ticket makes changes to the catalog package, along with the pagination package which is used in the catalog component.

Also ran `npm test -- -u` to update screenshots