### PR TITLE
fix: cart issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38997,17 +38997,41 @@
       "dependencies": {
         "@headlessui/react": "~1.5.0",
         "@thoughtindustries/content": "^1.2.0-beta.3",
+        "buffer": "^6.0.3",
         "clsx": "^1.1.1",
         "couponable": "^7.0.0",
         "i18next": "^21.10.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18",
         "react-i18next": "^11.18.6",
         "universal-cookie": "^4.0.4"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
+      }
+    },
+    "packages/cart/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "packages/catalog": {
@@ -52745,13 +52769,25 @@
       "requires": {
         "@headlessui/react": "~1.5.0",
         "@thoughtindustries/content": "^1.2.0-beta.3",
+        "buffer": "^6.0.3",
         "clsx": "^1.1.1",
         "couponable": "^7.0.0",
         "i18next": "^21.10.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18",
         "react-i18next": "^11.18.6",
         "universal-cookie": "^4.0.4"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "@thoughtindustries/catalog": {

--- a/packages/cart/__tests__/core/components/cart-provider/utilities.test.ts
+++ b/packages/cart/__tests__/core/components/cart-provider/utilities.test.ts
@@ -1,0 +1,123 @@
+import { EcommItemType } from '../../../../src/core/components/cart-provider/types';
+import {
+  parseCartCookie,
+  serializeCart
+} from '../../../../src/core/components/cart-provider/utilities';
+
+describe('@thoughtindustries/cart/core/CartProvider/utilities', () => {
+  describe('serializeCart', () => {
+    it('should serialize cart object to base64 string', () => {
+      const cart = {
+        items: [
+          {
+            purchasableType: EcommItemType.Course,
+            purchasableId: '1',
+            title: 'course-1',
+            priceInCents: 1000,
+            quantity: 1
+          },
+          {
+            purchasableType: EcommItemType.Product,
+            purchasableId: '2',
+            title: 'product-1',
+            priceInCents: 2500,
+            quantity: 3
+          }
+        ]
+      };
+
+      const actual = serializeCart(cart);
+      expect(actual).toMatchInlineSnapshot(
+        `"eyJpZCI6ImNhcnQiLCJjYXJ0SXRlbXMiOlt7InB1cmNoYXNhYmxlVHlwZSI6ImNvdXJzZSIsInB1cmNoYXNhYmxlSWQiOiIxIiwidGl0bGUiOiJjb3Vyc2UtMSIsInByaWNlSW5DZW50cyI6MTAwMCwicXVhbnRpdHkiOjF9LHsicHVyY2hhc2FibGVUeXBlIjoicHJvZHVjdCIsInB1cmNoYXNhYmxlSWQiOiIyIiwidGl0bGUiOiJwcm9kdWN0LTEiLCJwcmljZUluQ2VudHMiOjI1MDAsInF1YW50aXR5IjozfV19"`
+      );
+    });
+
+    it('should serialize cart object with non-binary data', () => {
+      const cart = {
+        items: [
+          {
+            purchasableType: EcommItemType.Course,
+            purchasableId: '1',
+            title: '测试',
+            priceInCents: 1000,
+            quantity: 1
+          }
+        ]
+      };
+
+      const actual = serializeCart(cart);
+      expect(actual).toMatchInlineSnapshot(
+        `"eyJpZCI6ImNhcnQiLCJjYXJ0SXRlbXMiOlt7InB1cmNoYXNhYmxlVHlwZSI6ImNvdXJzZSIsInB1cmNoYXNhYmxlSWQiOiIxIiwidGl0bGUiOiLmtYvor5UiLCJwcmljZUluQ2VudHMiOjEwMDAsInF1YW50aXR5IjoxfV19"`
+      );
+    });
+  });
+
+  describe('parseCartCookie', () => {
+    it('should return default cart when cookie is not set', () => {
+      const actual = parseCartCookie();
+      expect(actual).toMatchInlineSnapshot(`
+        Object {
+          "id": "cart",
+          "items": Array [],
+        }
+      `);
+    });
+
+    it('should return default cart when cookie value is invalid', () => {
+      const actual = parseCartCookie('invalid-value');
+      expect(actual).toMatchInlineSnapshot(`
+        Object {
+          "id": "cart",
+          "items": Array [],
+        }
+      `);
+    });
+
+    it('should return parsed cart object', () => {
+      const actual = parseCartCookie(
+        'eyJpZCI6ImNhcnQiLCJjYXJ0SXRlbXMiOlt7InB1cmNoYXNhYmxlVHlwZSI6ImNvdXJzZSIsInB1cmNoYXNhYmxlSWQiOiIxIiwidGl0bGUiOiJjb3Vyc2UtMSIsInByaWNlSW5DZW50cyI6MTAwMCwicXVhbnRpdHkiOjF9LHsicHVyY2hhc2FibGVUeXBlIjoicHJvZHVjdCIsInB1cmNoYXNhYmxlSWQiOiIyIiwidGl0bGUiOiJwcm9kdWN0LTEiLCJwcmljZUluQ2VudHMiOjI1MDAsInF1YW50aXR5IjozfV19'
+      );
+      expect(actual).toMatchInlineSnapshot(`
+        Object {
+          "id": "cart",
+          "items": Array [
+            Object {
+              "priceInCents": 1000,
+              "purchasableId": "1",
+              "purchasableType": "course",
+              "quantity": 1,
+              "title": "course-1",
+            },
+            Object {
+              "priceInCents": 2500,
+              "purchasableId": "2",
+              "purchasableType": "product",
+              "quantity": 3,
+              "title": "product-1",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should return parsed cart object with non-binary data', () => {
+      const actual = parseCartCookie(
+        'eyJpZCI6ImNhcnQiLCJjYXJ0SXRlbXMiOlt7InB1cmNoYXNhYmxlVHlwZSI6ImNvdXJzZSIsInB1cmNoYXNhYmxlSWQiOiIxIiwidGl0bGUiOiLmtYvor5UiLCJwcmljZUluQ2VudHMiOjEwMDAsInF1YW50aXR5IjoxfV19'
+      );
+      expect(actual).toMatchInlineSnapshot(`
+        Object {
+          "id": "cart",
+          "items": Array [
+            Object {
+              "priceInCents": 1000,
+              "purchasableId": "1",
+              "purchasableType": "course",
+              "quantity": 1,
+              "title": "测试",
+            },
+          ],
+        }
+      `);
+    });
+  });
+});

--- a/packages/cart/package.json
+++ b/packages/cart/package.json
@@ -26,11 +26,12 @@
   "dependencies": {
     "@headlessui/react": "~1.5.0",
     "@thoughtindustries/content": "^1.2.0-beta.3",
+    "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "couponable": "^7.0.0",
     "i18next": "^21.10.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^17 || ^18",
+    "react-dom": "^17 || ^18",
     "react-i18next": "^11.18.6",
     "universal-cookie": "^4.0.4"
   },

--- a/packages/cart/src/core/components/cart-provider/use-persist-reducer.ts
+++ b/packages/cart/src/core/components/cart-provider/use-persist-reducer.ts
@@ -22,7 +22,13 @@ export default function usePersistReducer(cookieName: string, cookieManager: Coo
       const { cart } = newState;
       // skip persisting cookie during initialization
       if (action.type !== CartActionType.InitializeCart) {
-        updateCookie(serializeCart(cart), { secure: false, httpOnly: false });
+        // disable default encoder encodeURIComponent
+        const encode = (value: string) => value;
+        updateCookie(serializeCart(cart), {
+          secure: false,
+          httpOnly: false,
+          encode
+        });
       }
       return newState;
     },

--- a/packages/cart/src/core/components/cart-provider/use-persist-reducer.ts
+++ b/packages/cart/src/core/components/cart-provider/use-persist-reducer.ts
@@ -27,6 +27,7 @@ export default function usePersistReducer(cookieName: string, cookieManager: Coo
         updateCookie(serializeCart(cart), {
           secure: false,
           httpOnly: false,
+          path: '/',
           encode
         });
       }

--- a/packages/cart/src/core/components/cart-provider/utilities.ts
+++ b/packages/cart/src/core/components/cart-provider/utilities.ts
@@ -10,6 +10,7 @@ import {
   VariationLabel
 } from './types';
 import { totalDueNow, totalRecurring } from 'couponable';
+import { Buffer as BufferForBrowser } from 'buffer';
 
 export const parseCartCookie = (cookie?: string): Cart => {
   const defaultCart: Cart = { id: CART_ID, items: [] };
@@ -18,9 +19,8 @@ export const parseCartCookie = (cookie?: string): Cart => {
   }
 
   try {
-    const base64Url = cookie.split('.')[0];
-    const base64 = base64Url.replace('-', '+').replace('_', '/');
-    const { cartItems: items = [] } = JSON.parse(window.atob(base64));
+    const cartPayload = BufferForBrowser.from(cookie, 'base64').toString('utf8');
+    const { cartItems: items = [] } = JSON.parse(cartPayload);
     return {
       ...defaultCart,
       items
@@ -35,7 +35,7 @@ export const serializeCart = (cart: Cart): string => {
     id: CART_ID,
     cartItems: [...cart.items]
   };
-  return window.btoa(JSON.stringify(clonedCart));
+  return BufferForBrowser.from(JSON.stringify(clonedCart)).toString('base64');
 };
 
 const findPackagePrice = (


### PR DESCRIPTION
Closes CLM-8820

changes:
- set cart cookie to path `/`
- override default encoder in `universal-cookie` when serializing cart cookie value
- currently the serialization/parsing of cookie value is handled by `window.atob` and `window.btoa`, which seems to work fine except for the handling of non-binary data. Replace it with `buffer` package to simulate node's `Buffer` API for browser.

verifications: deployed a test helium app along with some tweaks to the staging environment. The helium app only contains a dynamic path for '/courses/@courseSlug' which handles the cart rendering for ILT contents. Setup some ILT contents for purchase in staging. Verify the cart to be synced between the helium page and non-helium page. 

notes: helium feature flag is turned of in staging to avoid testing conflicts. one can turn on the feature flag to review the changes.