### PR TITLE
CLM-8914 Cart Translations Issue

### DIFF
--- a/tooling/cli/lib/parse-translations.js
+++ b/tooling/cli/lib/parse-translations.js
@@ -34,13 +34,10 @@ const KEYS_WITH_PLURALS = [];
 
   gatherPluralizedKeys();
 
-  const i18nStore = parser.get();
-  // en is default lang and lms is default namespace, so all keys used should be in that object
-  const i18nNSObject = i18nStore.en && i18nStore.en.lms ? i18nStore.en.lms : {};
-  const usedTranslationKeys = Object.keys(i18nNSObject);
+  const usedTranslationKeys = Object.keys(sourceDefaultNamespace);
 
   for (const key of usedTranslationKeys) {
-    const translationValue = i18nNSObject[key];
+    const translationValue = usedTranslationKeys[key];
 
     // while the keys are saved in TI files as home.meta-title, the parser will automatically
     // turn that to `home: { 'meta-title': translationValue }`


### PR DESCRIPTION
Closes CLM-8914

Issue: Cart translations were not working in a deployed environment, but did work locally. [Video of issue](https://www.loom.com/share/550479a2730f490eb2e22cb8bb136b98?sid=4c3211db-f7f1-499d-8ae6-09463158d731)

The issue is with the `i18nObject`, as it was not picking up all translations. The issue is resolved by using the `sourceDefaultNamespace` to map translations instead. 

I tested this using the `Cart` component as detailed in the ticket, but also tested the `Catalog` component to ensure that the translations were still working for other helium components. All looks good in testing.

Please let me know if there is any reason why we should use `i18nObject` instead of `sourceDefaultNamespace`.