### PR TITLE
Feat: Allow configuring paths for plucked GraphQL Operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39253,6 +39253,7 @@
         "i18next-scanner": "^3.1.0",
         "inquirer": "^8.1.2",
         "isomorphic-unfetch": "^3.1.0",
+        "minimatch": "^9.0.3",
         "tar": "^6.1.11",
         "yargs": "^17.1.1"
       },
@@ -39265,6 +39266,28 @@
       "engines": {
         "node": ">=16.18.1",
         "npm": ">=8.19.2"
+      }
+    },
+    "tooling/cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "tooling/cli/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "tooling/create-helium-app": {
@@ -52921,8 +52944,27 @@
         "i18next-scanner": "^3.1.0",
         "inquirer": "^8.1.2",
         "isomorphic-unfetch": "^3.1.0",
+        "minimatch": "*",
         "tar": "^6.1.11",
         "yargs": "^17.1.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@thoughtindustries/helium-server": {

--- a/tooling/cli/lib/file-generators.js
+++ b/tooling/cli/lib/file-generators.js
@@ -1,6 +1,7 @@
 const { writeFile } = require('fs/promises');
 const path = require('path');
 const { fetchTranslations, writeTranslationFile } = require('./helpers/translations');
+const { DEFAULT_GRAPHQL_SOURCE_PATHS } = require('./helpers/constants');
 
 const initProject = async (dir, instances) => {
   console.log('Generating env file...');
@@ -54,7 +55,17 @@ const generateConfigFile = async (dir, instances) => {
     });
   }
 
-  return writeFile(fileName, JSON.stringify({ instances: data }, null, 2));
+  return writeFile(
+    fileName,
+    JSON.stringify(
+      {
+        content: DEFAULT_GRAPHQL_SOURCE_PATHS,
+        instances: data
+      },
+      null,
+      2
+    )
+  );
 };
 
 module.exports = { initProject, generateTranslationFile };

--- a/tooling/cli/lib/helpers/constants.js
+++ b/tooling/cli/lib/helpers/constants.js
@@ -1,0 +1,6 @@
+module.export = {
+  DEFAULT_GRAPHQL_SOURCE_PATHS: [
+    './pages/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}'
+  ]
+};

--- a/tooling/cli/lib/helpers/filepaths.js
+++ b/tooling/cli/lib/helpers/filepaths.js
@@ -1,7 +1,7 @@
 const { readdir, stat } = require('fs/promises');
 const path = require('path');
 
-const getFilePaths = async (dir, filePaths = []) => {
+const getFilePaths = async (dir, filePaths = [], skipNodeModules = true) => {
   const newFilePaths = filePaths;
 
   try {
@@ -14,6 +14,12 @@ const getFilePaths = async (dir, filePaths = []) => {
       if (fileStat.isFile()) {
         newFilePaths.push(filePath);
       } else {
+        if (skipNodeModules) {
+          if (filePath.includes('node_modules') && !filePath.includes('@thoughtindustries')) {
+            continue;
+          }
+        }
+
         await getFilePaths(filePath, newFilePaths);
       }
     }

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -19,6 +19,7 @@
     "i18next-scanner": "^3.1.0",
     "inquirer": "^8.1.2",
     "isomorphic-unfetch": "^3.1.0",
+    "minimatch": "^9.0.3",
     "tar": "^6.1.11",
     "yargs": "^17.1.1"
   },


### PR DESCRIPTION
Closes CLM-9414

- Adds a `content` property to the generated `ti-config.json` with default `pages` and `components` value.
- When using the `deploy` command, all project paths will be gathered, then filtered against paths stored in `ti-config.content`.
- Resulting array of paths is `concat` w/ `node_modules/@thoughtindustries`, and the final array is used to pluck GraphQL operations.