### PR TITLE
feat: allow deployment of development builds

### DIFF
--- a/tooling/cli/README.md
+++ b/tooling/cli/README.md
@@ -76,6 +76,10 @@ Which instance from your `ti-config.json` file to be used, as noted by the insta
 
 Used when the Thought Industries instance is behind an untrusted SSL certificate (e.g., local development).
 
+`-d`, `-development` (optional)
+
+Used to deploy a Development build of the Helium project to unobfuscate errors.
+
 ### `update-translations`
 
 ```sh

--- a/tooling/cli/lib/command-modules/deploy.js
+++ b/tooling/cli/lib/command-modules/deploy.js
@@ -13,6 +13,12 @@ exports.builder = cmd => {
       type: 'string',
       describe: 'Nickname of instance to deploy'
     })
+    .option('d', {
+      alias: 'debug',
+      type: 'boolean',
+      describe: 'Build and deploy Development build of application',
+      default: false
+    })
     .option('k', {
       alias: 'insecure',
       type: 'boolean',
@@ -25,6 +31,7 @@ exports.handler = function (argv) {
   const env = {
     ...process.env,
     INSTANCE_NAME: argv.instance,
+    DEBUG_BUILD: argv.debug,
     NODE_TLS_REJECT_UNAUTHORIZED: argv.insecure ? '0' : '1'
   };
 

--- a/tooling/cli/lib/command-modules/deploy.js
+++ b/tooling/cli/lib/command-modules/deploy.js
@@ -14,7 +14,7 @@ exports.builder = cmd => {
       describe: 'Nickname of instance to deploy'
     })
     .option('d', {
-      alias: 'debug',
+      alias: 'development',
       type: 'boolean',
       describe: 'Build and deploy Development build of application',
       default: false
@@ -31,7 +31,7 @@ exports.handler = function (argv) {
   const env = {
     ...process.env,
     INSTANCE_NAME: argv.instance,
-    DEBUG_BUILD: argv.debug,
+    DEVELOPMENT_BUILD: argv.development,
     NODE_TLS_REJECT_UNAUTHORIZED: argv.insecure ? '0' : '1'
   };
 

--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -27,6 +27,7 @@ const configPath = path.join(OP_DIR, '/ti-config');
 const config = require(configPath);
 
 const INSTANCE_NAME = process.env.INSTANCE_NAME;
+const DEBUG_BUILD = process.env.DEBUG_BUILD;
 
 const KEY_QUERY = /* GraphQL */ `
   query CompanyDetailsQuery($nickname: String!) {
@@ -142,7 +143,12 @@ process.on('message', message => {
 async function buildProject(hasAtoms) {
   return new Promise((resolve, reject) => {
     const exec = childProcess.exec;
-    const buildCommandSuffix = hasAtoms ? 'atoms' : 'vite';
+
+    let buildCommandSuffix = hasAtoms ? 'atoms' : 'vite';
+    if (buildCommandSuffix === 'vite' && !!DEBUG_BUILD) {
+      buildCommandSuffix = 'development';
+    }
+
     const parseProcess = exec(`npm run build:css && npm run build:${buildCommandSuffix}`);
 
     parseProcess.stdout.pipe(process.stdout);

--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -27,7 +27,7 @@ const configPath = path.join(OP_DIR, '/ti-config');
 const config = require(configPath);
 
 const INSTANCE_NAME = process.env.INSTANCE_NAME;
-const DEBUG_BUILD = process.env.DEBUG_BUILD;
+const DEVELOPMENT_BUILD = process.env.DEVELOPMENT_BUILD;
 
 const KEY_QUERY = /* GraphQL */ `
   query CompanyDetailsQuery($nickname: String!) {
@@ -145,7 +145,7 @@ async function buildProject(hasAtoms) {
     const exec = childProcess.exec;
 
     let buildCommandSuffix = hasAtoms ? 'atoms' : 'vite';
-    if (buildCommandSuffix === 'vite' && !!DEBUG_BUILD) {
+    if (buildCommandSuffix === 'vite' && !!DEVELOPMENT_BUILD) {
       buildCommandSuffix = 'development';
     }
 

--- a/tooling/cli/lib/file-generators.js
+++ b/tooling/cli/lib/file-generators.js
@@ -5,7 +5,8 @@ const { DEFAULT_GRAPHQL_SOURCE_PATHS } = require('./helpers/constants');
 
 const initProject = async (dir, instances) => {
   console.log('Generating env file...');
-  await generateEnvFile(dir, instances);
+  await generateEnvFile(dir);
+  await generateEnvFile(dir, true);
 
   console.log('Generating translations file...');
   await generateTranslationFile(dir, instances);
@@ -14,13 +15,9 @@ const initProject = async (dir, instances) => {
   return generateConfigFile(dir, instances);
 };
 
-const generateEnvFile = async (dir, instances) => {
-  const fileName = path.resolve(dir, '.env');
-  let data = '';
-
-  instances.forEach(instance => {
-    data += `TI_${instance.nickname}_API_KEY=${instance.apiKey}\n`;
-  });
+const generateEnvFile = async (dir, development = false) => {
+  const fileName = path.resolve(dir, development ? '.env.development' : '.env');
+  const data = `NODE_ENV=${development ? 'development' : 'production'}`;
 
   return writeFile(fileName, data);
 };

--- a/tooling/template-base-essentials/package.json
+++ b/tooling/template-base-essentials/package.json
@@ -11,7 +11,8 @@
     "dev:server": "tsup ./server/index.ts && node ./dist/index.js",
     "build": "npm run build:css && npm run build:vite",
     "build:css": "tailwindcss -o ./renderer/tailwind.css",
-    "build:vite": "vite build"
+    "build:vite": "vite build",
+    "build:development": "vite build --mode development"
   },
   "publishConfig": {
     "access": "public"

--- a/tooling/template-base/package.json
+++ b/tooling/template-base/package.json
@@ -11,7 +11,8 @@
     "dev:server": "tsup ./server/index.ts && node ./dist/index.js",
     "build": "npm run build:css && npm run build:vite",
     "build:css": "tailwindcss -o ./renderer/tailwind.css",
-    "build:vite": "vite build"
+    "build:vite": "vite build",
+    "build:development": "vite build --mode development"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Closes CLM-10089

This change allows users to pass a `-d`/`-debug` flag when running `helium deploy`/`npm run deploy` in order to deploy a development build to assist troubleshooting efforts.

In order to do so, users will need to a `.env.development` file with `NODE_ENV='development'`.

<img width="936" alt="Screen Shot 2023-11-06 at 13 32 00" src="https://github.com/thoughtindustries/helium/assets/16481068/705a0a6f-b862-405f-b3aa-b659e53492be">
