### PR TITLE
fix: fix check where development build env var assigned as string

### DIFF
--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -145,7 +145,7 @@ async function buildProject(hasAtoms) {
     const exec = childProcess.exec;
 
     let buildCommandSuffix = hasAtoms ? 'atoms' : 'vite';
-    if (buildCommandSuffix === 'vite' && !!DEVELOPMENT_BUILD) {
+    if (buildCommandSuffix === 'vite' && String(DEVELOPMENT_BUILD) === 'true') {
       buildCommandSuffix = 'development';
     }
 


### PR DESCRIPTION
Fixes CLM-10089

`DEVELOPMENT_BUILD` ends up getting passed as a string in `process.env`. This change fixes the check where we verify if the development build flag was passed.