### PR TITLE
fix: temporarily rename env files when using development build commands

### DIFF
--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -174,7 +174,7 @@ async function swapEnvFiles(target, source, newFilePath) {
 
   if (hasTarget && hasSource) {
     const newPath = path.join(OP_DIR, newFilePath);
-    await rename(target, newPath);
+    await rename(targetPath, newPath);
     await rename(sourcePath, targetPath);
   }
 

--- a/tooling/cli/lib/deploy.js
+++ b/tooling/cli/lib/deploy.js
@@ -8,7 +8,7 @@ const childProcess = require('child_process');
 const tar = require('tar');
 const os = require('os');
 
-const { getFilePaths } = require('./helpers/filepaths');
+const { getFilePaths, getFileContents } = require('./helpers/filepaths');
 const { instanceEndpoint } = require('./helpers/urls');
 const { generateTranslationFile } = require('./file-generators');
 const {
@@ -104,8 +104,13 @@ class DeploymentError extends Error {
 
   // hash queries for whitelisting
   await writeGraphqlManifest();
+
+  await maybeRenameEnvFile();
+
   await uploadHeliumProject(policyData);
-  // reset translations file to include all keys for local development
+
+  await maybeResetEnvFile();
+  // // reset translations file to include all keys for local development
   await resetTranslationFile();
   const batchJobId = await triggerBatch(instance, key);
 
@@ -140,12 +145,52 @@ process.on('message', message => {
   console.log('>>> Deploy process receive message', message);
 });
 
+async function maybeRenameEnvFile() {
+  // temporarily swap env files if it's a dev build.
+  // the CF Worker still loads an env file into process.env if it's present
+  // so we could end up with a project built with .env.development running
+  // w/ vars passed from .env instead.
+  if (isDevelopmentBuild()) {
+    await swapEnvFiles('.env', '.env.development', '.env.backup');
+  }
+
+  return;
+}
+
+async function maybeResetEnvFile() {
+  if (isDevelopmentBuild()) {
+    await swapEnvFiles('.env', '.env.backup', '.env.development');
+  }
+
+  return;
+}
+
+async function swapEnvFiles(target, source, newFilePath) {
+  const targetPath = path.join(OP_DIR, target);
+  const sourcePath = path.join(OP_DIR, source);
+
+  const hasTarget = await getFileContents(targetPath);
+  const hasSource = await getFileContents(sourcePath);
+
+  if (hasTarget && hasSource) {
+    const newPath = path.join(OP_DIR, newFilePath);
+    await rename(target, newPath);
+    await rename(sourcePath, targetPath);
+  }
+
+  return;
+}
+
+function isDevelopmentBuild() {
+  return String(DEVELOPMENT_BUILD) === 'true';
+}
+
 async function buildProject(hasAtoms) {
   return new Promise((resolve, reject) => {
     const exec = childProcess.exec;
 
     let buildCommandSuffix = hasAtoms ? 'atoms' : 'vite';
-    if (buildCommandSuffix === 'vite' && String(DEVELOPMENT_BUILD) === 'true') {
+    if (buildCommandSuffix === 'vite' && isDevelopmentBuild()) {
       buildCommandSuffix = 'development';
     }
 

--- a/tooling/cli/lib/helpers/atoms.js
+++ b/tooling/cli/lib/helpers/atoms.js
@@ -1,6 +1,6 @@
-const { getFilePaths } = require('./filepaths');
+const { getFilePaths, getFileContents } = require('./filepaths');
 const path = require('path');
-const { access, readFile, writeFile } = require('fs/promises');
+const { writeFile } = require('fs/promises');
 const crypto = require('crypto');
 
 const dirHasAtoms = async dir => {
@@ -52,16 +52,6 @@ const compileStyles = async (dir, atomsStyleHash) => {
   await writeFile(updatedStylePath, styles, { encoding: 'utf8' });
 
   return updatedStyleHash;
-};
-
-const getFileContents = async path => {
-  try {
-    await access(path);
-    const contents = await readFile(path);
-    return contents;
-  } catch {
-    return null;
-  }
 };
 
 module.exports = { dirHasAtoms, getAtomsHash, compileStyles };

--- a/tooling/cli/lib/helpers/filepaths.js
+++ b/tooling/cli/lib/helpers/filepaths.js
@@ -1,5 +1,6 @@
 const { readdir, stat } = require('fs/promises');
 const path = require('path');
+const { access, readFile } = require('fs/promises');
 
 const getFilePaths = async (dir, filePaths = [], skipNodeModules = true) => {
   const newFilePaths = filePaths;
@@ -36,4 +37,14 @@ const filePathIsValid = filePath => {
   );
 };
 
-module.exports = { getFilePaths, filePathIsValid };
+const getFileContents = async path => {
+  try {
+    await access(path);
+    const contents = await readFile(path);
+    return contents;
+  } catch {
+    return null;
+  }
+};
+
+module.exports = { getFilePaths, filePathIsValid, getFileContents };


### PR DESCRIPTION
Continues CLM-10089

- Moves `getFileContents` from `/helpers/atoms` to more appropriate `/helpers/filepaths`.
- Updates `deploy` command to temporarily rename `.env.development` to `.env` when deploying development builds, with the files resetting after upload.