### PR TITLE
feat: add check for HELIUM_PRIVATE_ENABLE_ASSET_PROXY

### DIFF
--- a/tooling/helium-server/worker/ssr.js
+++ b/tooling/helium-server/worker/ssr.js
@@ -58,8 +58,10 @@ async function handleSsr(url, authToken = null, userAndAppearanceToken = null) {
   } else {
     const { statusCode, body } = httpResponse;
     const headers = assembleHeaders(pageContext);
+    const resBody =
+      HELIUM_PRIVATE_ENABLE_ASSET_PROXY === 'true' ? body : resolveAssetUrls(url, body);
 
-    return new Response(resolveAssetUrls(url, body), {
+    return new Response(resBody, {
       headers,
       status: statusCode
     });


### PR DESCRIPTION
Closes CLM-10925

Adds check for `HELIUM_PRIVATE_ENABLE_ASSET_PROXY` env var. 

If `HELIUM_PRIVATE_ENABLE_ASSET_PROXY=true`, we'll leave asset URLs as written and proxy through Thought Industries backend.