### PR TITLE
TI-626 Routing Issue with Dashboard Bug

### DIFF
--- a/tooling/template-base/components/Signin/SigninPage.tsx
+++ b/tooling/template-base/components/Signin/SigninPage.tsx
@@ -19,7 +19,7 @@ const SigninPage = () => {
       variables: { email: userEmail, password: userPassword }
     })
       .then(() => {
-        window.location.href = '/learn/';
+        window.location.href = '/learn/dashboard';
       })
       .catch(error => {
         console.log('Handle Login Mutation Error Here');


### PR DESCRIPTION
Resolves [TI-626](https://thoughtindustries.atlassian.net/browse/TI-626)

When replacing the dashboard component, on login, the user would be led to the native dashboard (/learn/) instead of (/learn/dashboard). This fix adds "dashboard" to the end of the `window.location.href` during login to lead the user to the correct dashboard. 

[TI-626]: https://thoughtindustries.atlassian.net/browse/TI-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ