### PR TITLE
[TI-3149] - Fix character encoding for special characters

### DIFF
--- a/tooling/helium-server/src/server/server.ts
+++ b/tooling/helium-server/src/server/server.ts
@@ -177,9 +177,9 @@ export default async function setupHeliumServer(root: string, viteDevServer: any
       // Vike returns the pageContext in httpResponse.body for .pageContext.json requests
       if (httpResponse) {
         const { statusCode, body } = httpResponse;
-        // Set proper content type for JSON responses
+        // Set proper content type for JSON responses with charset for proper encoding
         if (body && (body.startsWith('{') || body.startsWith('['))) {
-          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Content-Type', 'application/json; charset=utf-8');
         }
         res.status(statusCode).send(body);
       } else {
@@ -191,6 +191,8 @@ export default async function setupHeliumServer(root: string, viteDevServer: any
       if (!httpResponse) return next();
 
       const { statusCode, body } = httpResponse;
+      // Set proper content type with charset for proper encoding of special characters
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.status(statusCode).send(body);
     }
   });

--- a/tooling/helium-server/worker/ssr.js
+++ b/tooling/helium-server/worker/ssr.js
@@ -112,7 +112,10 @@ function decryptUserAndAppearance(userAndAppearanceToken, tiInstance) {
 function assembleHeaders(pageContext, isClientRoutingRequest = false) {
   // For Client Routing navigation requests, return JSON
   // For regular page loads, return HTML
-  const contentType = isClientRoutingRequest ? 'application/json' : 'text/html';
+  // Always include charset=utf-8 to ensure proper encoding of special characters
+  const contentType = isClientRoutingRequest
+    ? 'application/json; charset=utf-8'
+    : 'text/html; charset=utf-8';
   const headers = { 'content-type': contentType };
 
   if (pageContext && pageContext.documentProps) {


### PR DESCRIPTION
Add charset=utf-8 to Content-Type headers for proper special character encoding

Fixes encoding issues where special characters (accented letters, emojis, non-ASCII characters) from external data sources like Contentstack were rendering incorrectly after deployment.

Root cause: HTTP/1.1 defaults to ISO-8859-1 (Latin-1) when charset is not specified in Content-Type header. UTF-8 encoded content was being misinterpreted as Latin-1.

Changes:
- worker/ssr.js: Add charset=utf-8 to text/html and application/json responses
- src/server/server.ts: Add charset=utf-8 to dev server responses for consistency