### PR TITLE
fix: exclude .d.ts files from GraphQL tag plucking (TI-4862)

### DIFF
--- a/tooling/cli/__tests__/filepaths.test.js
+++ b/tooling/cli/__tests__/filepaths.test.js
@@ -1,0 +1,33 @@
+const { filePathIsValid } = require('./../lib/helpers/filepaths');
+
+describe('@thoughtindustries/tooling/cli/helpers/filepaths', () => {
+  describe('filePathIsValid', () => {
+    it.each([
+      ['component.js'],
+      ['component.jsx'],
+      ['component.ts'],
+      ['component.tsx'],
+      ['src/pages/Home.tsx'],
+      ['node_modules/@thoughtindustries/content/src/index.ts']
+    ])('returns true for runtime source file %s', filePath => {
+      expect(filePathIsValid(filePath)).toBe(true);
+    });
+
+    it.each([
+      ['index.d.ts'],
+      ['types.d.tsx'],
+      ['node_modules/@apollo/client/index.d.ts'],
+      ['node_modules/vike/dist/types.d.ts'],
+      ['node_modules/@thoughtindustries/content/dist/index.d.ts']
+    ])('returns false for declaration file %s', filePath => {
+      expect(filePathIsValid(filePath)).toBe(false);
+    });
+
+    it.each([['styles.css'], ['image.png'], ['data.json'], ['README.md'], ['config.yaml']])(
+      'returns false for non-script file %s',
+      filePath => {
+        expect(filePathIsValid(filePath)).toBe(false);
+      }
+    );
+  });
+});

--- a/tooling/cli/lib/helpers/filepaths.js
+++ b/tooling/cli/lib/helpers/filepaths.js
@@ -29,6 +29,9 @@ const getFilePaths = async (dir, filePaths = [], skipNodeModules = true) => {
 };
 
 const filePathIsValid = filePath => {
+  if (filePath.endsWith('.d.ts') || filePath.endsWith('.d.tsx')) {
+    return false;
+  }
   return (
     filePath.endsWith('.js') ||
     filePath.endsWith('.jsx') ||


### PR DESCRIPTION
## What does this PR do?

Resolves [TI-4862](https://thoughtindustries.atlassian.net/browse/TI-4862)

`helium deploy` fails after a successful Vite build with `SyntaxError: Missing initializer in const declaration` from `@babel/parser`. The root cause: `filePathIsValid` in `tooling/cli/lib/helpers/filepaths.js` uses `.endsWith('.ts')` which matches `.d.ts` (TypeScript declaration) files. During deploy, `hashGraphqlQueries()` scans `node_modules/@thoughtindustries/` with `skipNodeModules = false`, traversing into nested dependency declaration files (vike, @apollo/client, vite) that contain ambient syntax (`export declare const ...`) which `@babel/parser` cannot parse as runtime code.

**Fix:** Add an early return in `filePathIsValid` that rejects `.d.ts` and `.d.tsx` files before checking valid extensions. Declaration files never contain GraphQL `gql` tagged template literals and should never be passed to `@graphql-tools/graphql-tag-pluck`.

### Changes
- `tooling/cli/lib/helpers/filepaths.js` — added `.d.ts` / `.d.tsx` exclusion guard
- `tooling/cli/__tests__/filepaths.test.js` — new regression test covering valid extensions, declaration file exclusion, and non-script file rejection

### Validation
- **`filepaths.js:35`**: `filePath.endsWith('.ts')` would match `'foo.d.ts'` — confirmed by adding `filePath.endsWith('.d.ts')` early-return guard before it
- **`deploy.js:251-255`**: `hashGraphqlQueries()` calls `getFilePaths(…, [], false)` which traverses nested `node_modules` — confirmed this is the entry point that surfaces `.d.ts` files
- **`graphql.js:16-18`**: `gatherQuerySources` passes `filePathIsValid` results directly to `gqlPluckFromCodeString` — confirmed the guard prevents `.d.ts` files from reaching `@babel/parser`
- Both consumers of `filePathIsValid` (`graphql.js` for tag plucking, `parse-translations.js` for i18next scanning) benefit from the exclusion — declaration files contain neither

## How should this be further tested?

1. Create a project from `template-base` with dependencies that ship `.d.ts` files (standard setup — vike, @apollo/client, vite all do)
2. Run `helium deploy`
3. **Expected:** deploy completes without `SyntaxError: Missing initializer in const declaration`
4. Verify the generated `dist/client/graphql-manifest.json` contains the expected query hashes (same as before the fix — no queries were lost by excluding declaration files)

## Checklist
- [x] No TypeScript suppressions (`@ts-ignore`, `@ts-expect-error`, `eslint-disable`)
- [x] Jest regression test covers real branches (valid, declaration, non-script)
- [x] Conventional Commit style (`fix:`)
- [x] No secrets, internal URLs, or customer identifiers
- [x] Existing `graphql.test.js` tests still pass

[TI-4862]: https://thoughtindustries.atlassian.net/browse/TI-4862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ